### PR TITLE
Fixed issue when no subtitle stream is available

### DIFF
--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -540,7 +540,11 @@ def start_playback(args, api: API):
     # vo_drm_adaptive_hls
 
     try:
-        url = req["streams"]["adaptive_hls"][args.subtitle]["url"]
+        url = req["streams"]["adaptive_hls"]
+        if args.subtitle in url:
+            url = url[args.subtitle]["url"]
+        else:
+            url = url[""]["url"]
     except IndexError:
         item = xbmcgui.ListItem(getattr(args, "title", "Title not provided"))
         xbmcplugin.setResolvedUrl(int(args.argv[1]), False, item)


### PR DESCRIPTION
I found one video with playback issues, because it didn't have a subtitle stream.
I prepared a change that will check if the subtitle stream exists and use the empty string if not (which is valid).