### PR TITLE
Add a setting to enable soft subtitles

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -32,6 +32,10 @@ msgctxt "#30004"
 msgid "Configure InputStream Adaptive"
 msgstr "InputStream Adaptive konfigurieren"
 
+msgctxt "#30005"
+msgid "Soft Subtitles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Untertitel Sprache"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -32,6 +32,10 @@ msgctxt "#30004"
 msgid "Configure InputStream Adaptive"
 msgstr ""
 
+msgctxt "#30005"
+msgid "Soft Subtitles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -31,6 +31,10 @@ msgctxt "#30004"
 msgid "Configure InputStream Adaptive"
 msgstr "Configurer InputStream Adaptive"
 
+msgctxt "#30005"
+msgid "Soft Subtitles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Language des sous titres"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -31,6 +31,10 @@ msgctxt "#30004"
 msgid "Configure InputStream Adaptive"
 msgstr "Configuração do plugin InputStream Adaptive"
 
+msgctxt "#30005"
+msgid "Soft Subtitles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Linguagem da legenda"

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -753,9 +753,8 @@ def start_playback(args, api: API):
             else:
                 url = url[""]["url"]
         else:
-            #software subtitles
-            url = req["streams"]["multitrack_adaptive_hls_v2"]
-            url = url[""]["url"]
+            #multitrack_adaptive_hls_v2 includes soft subtitles in the stream
+            url = req["streams"]["multitrack_adaptive_hls_v2"][""]["url"]
     except IndexError:
         item = xbmcgui.ListItem(getattr(args, "title", "Title not provided"))
         xbmcplugin.setResolvedUrl(int(args.argv[1]), False, item)

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -743,13 +743,18 @@ def start_playback(args, api: API):
     # vo_drm_adaptive_dash
     # vo_drm_adaptive_hls
 
-    try:
-        url = req["streams"]["adaptive_hls"]
-        if args.subtitle in url:
-            url = url[args.subtitle]["url"]
-        elif args.subtitle_fallback in url:
-            url = url[args.subtitle_fallback]["url"]
+    try:        
+        if args.addon.getSetting("soft_subtitles") == "false":
+            url = req["streams"]["adaptive_hls"]
+            if args.subtitle in url:
+                url = url[args.subtitle]["url"]
+            elif args.subtitle_fallback in url:
+                url = url[args.subtitle_fallback]["url"]
+            else:
+                url = url[""]["url"]
         else:
+            #software subtitles
+            url = req["streams"]["multitrack_adaptive_hls_v2"]
             url = url[""]["url"]
     except IndexError:
         item = xbmcgui.ListItem(getattr(args, "title", "Title not provided"))

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -771,6 +771,7 @@ def start_playback(args, api: API):
     if is_helper.check_inputstream():
         item.setProperty("inputstream", "inputstream.adaptive")
         item.setProperty("inputstream.adaptive.manifest_type", "hls")
+        item.setSubtitles([req["subtitles"][args.subtitle]["url"]])
         # start playback
         xbmcplugin.setResolvedUrl(int(args.argv[1]), True, item)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -8,6 +8,7 @@
     <setting type="sep" />
     <setting id="subtitle_language" type="select" lvalues="30021|30022|30023|30024|30025|30026|30027|30028|30029|30030|30031" label="30020" default="0" />
     <setting id="subtitle_language_fallback" type="select" lvalues="30021|30022|30023|30024|30025|30026|30027|30028|30029|30030|30031|30070" label="30069" default="11" />
+    <setting id="soft_subtitles" type="bool" label="30005" default="false"/>
     <setting id="sync_playtime" type="bool" label="30003" default="true"/>
     <setting id="inputstream_adaptive" type="action" label="30004" option="close" action="RunPlugin(plugin://plugin.video.crunchyroll/?mode=hls)"/>
 </settings>


### PR DESCRIPTION
When the setting is enabled we choose a video stream without hardsubs and use the "multitrack_adaptive_hls_v2" stream which embeds the soft subtitles.