### PR TITLE
refactor: The same code, three times, it's a lot!

### DIFF
--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -26,7 +26,6 @@ import xbmcgui
 from . import utils
 from . import view
 from .api import API
-from .model import EpisodeData, MovieData
 from .videoplayer import VideoPlayer
 
 
@@ -52,7 +51,9 @@ def show_queue(args, api: API):
     # @TODO: re-add filtering of non-available items / premium content
     # if not ("most_likely_media" in item and "series" in item and item["most_likely_media"]["available"] and item["most_likely_media"]["premium_available"]):
     #    continue
+
     utils.add_items_to_view(req.get("items"), args, api)
+
     # # potentially unsafe, it can possibly delete the whole playlist if something goes really wrong
     # callback=lambda li:
     #     li.addContextMenuItems([(args.addon.getLocalizedString(30068), 'RunPlugin(%s?mode=remove_from_queue&content_id=%s&session_restart=True)' % (sys.argv[0], entry.episode_id))])

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -570,8 +570,8 @@ def view_series(args, api: API):
                     "aired": None,  # item["created"][:10],
                     "premiered": None,  # item["created"][:10],
                     "status": u"Completed" if item["is_complete"] else u"Continuing",
-                    "thumb": args.thumb,
-                    "fanart": args.fanart,
+                    # "thumb": args.thumb,  # @todo: re-add
+                    # "fanart": args.fanart, # @todo: re-add
                     "mode": "episodes"
                 },
                 is_folder=True
@@ -649,9 +649,9 @@ def view_episodes(args, api: API):
                     "plotoutline": item["description"],
                     "aired": item["episode_air_date"][:10],
                     "premiered": item["availability_starts"][:10],  # ???
-                    "poster": args.thumb,
+                    # "poster": args.thumb,  # @todo: re-add
                     "thumb": utils.get_image_from_struct(item, "thumbnail", 2),
-                    "fanart": args.fanart,
+                    # "fanart": args.fanart,  # @todo: re-add
                     "mode": "videoplay",
                     # note that for fetching streams we need a special guid, not the episode_id
                     "stream_id": stream_id,

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -454,32 +454,6 @@ def list_filter(args, mode, api: API):
 
     view.end_of_directory(args, "tvshows")
 
-    # @TODO: update
-    #
-    # # test if filter is selected
-    # if hasattr(args, "search"):
-    #     return listSeries(args, "tag:" + args.search)
-    #
-    # # api request
-    # payload = {"media_type": args.genre}
-    # req = api.request(args, "categories", payload)
-    #
-    # # check for error
-    # if "error" in req:
-    #     view.add_item(args, {"title": args.addon.getLocalizedString(30061)})
-    #     view.endofdirectory(args)
-    #     return False
-    #
-    # # display media
-    # for item in req["data"][mode]:
-    #     # add to view
-    #     view.add_item(args,
-    #                   {"title": item["label"],
-    #                    "search": item["tag"],
-    #                    "mode": args.mode},
-    #                   is_folder=True)
-    #
-    # view.endofdirectory(args)
     return True
 
 
@@ -597,9 +571,6 @@ def view_episodes(args, api: API):
             "season_id": args.collection_id
         }
     )
-
-    # @TODO: collect all episodes ids and make a call to "playheads" api endpoint,
-    #        to find out if and which we haven't seen fully yet.
 
     # check for error
     if not req or "error" in req:

--- a/resources/lib/crunchyroll.py
+++ b/resources/lib/crunchyroll.py
@@ -126,7 +126,7 @@ def check_mode(args, api: API):
 
     elif mode == "featured":  # https://www.crunchyroll.com/content/v2/discover/account_id/home_feed -> hero_carousel ?
         controller.listSeries(args, "featured", api)
-    elif mode == "popular":  # DONE
+    elif mode == "popular":
         controller.list_filter(args, "popular", api)
     # elif mode == "simulcast":  # https://www.crunchyroll.com/de/simulcasts/seasons/fall-2023 ???
     #     controller.listSeries(args, "simulcast", api)
@@ -136,9 +136,9 @@ def check_mode(args, api: API):
         controller.list_filter(args, "newest", api)
     elif mode == "alpha":
         controller.list_filter(args, "alpha", api)
-    elif mode == "season":  # DONE
+    elif mode == "season":
         controller.list_seasons(args, "season", api)
-    elif mode == "genre":  # DONE
+    elif mode == "genre":
         controller.list_filter(args, "genre", api)
 
     elif mode == "series":

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -140,6 +140,8 @@ class AccountData(Object):
         self.username: str = data.get("username")
 
 
+
+# @todo: create common base class
 class MovieData(Object):
     def __init__(self, data: dict):
         from . import utils
@@ -191,6 +193,7 @@ class MovieData(Object):
 
 
 # dto
+# @todo: create common base class
 class EpisodeData(Object):
     def __init__(self, data: dict):
         from . import utils
@@ -240,6 +243,7 @@ class EpisodeData(Object):
 
 
 # dto
+# @todo: create common base class
 class SeriesData(Object):
     def __init__(self, data: dict):
         from . import utils

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -144,7 +144,7 @@ class MovieData(Object):
     def __init__(self, data: dict):
         from . import utils
 
-        meta = data.get("panel").get("movie_metadata")
+        meta = data.get("movie_metadata")
 
         self.title: str = meta.get("movie_listing_title", "")
         self.tvshowtitle: str = meta.get("movie_listing_title", "")
@@ -152,32 +152,32 @@ class MovieData(Object):
         self.playhead: int = data.get("playhead", 0)
         self.season: str = ""
         self.episode: str = "1"
-        self.episode_id: str | None = data.get("panel", {}).get("id")
+        self.episode_id: str | None = data.get("id")
         self.collection_id: str | None = None
         self.series_id: str | None = None
-        self.plot: str = data.get("panel", {}).get("description", "")
-        self.plotoutline: str = data.get("panel", {}).get("description", "")
+        self.plot: str = data.get("description", "")
+        self.plotoutline: str = data.get("description", "")
         self.year: str = meta.get("premium_available_date")[:10] if meta.get(
             "premium_available_date") is not None else ""
         self.aired: str = meta.get("premium_available_date")[:10] if meta.get(
             "premium_available_date") is not None else ""
         self.premiered: str = meta.get("premium_available_date")[:10] if meta.get(
             "premium_available_date") is not None else ""
-        self.thumb: str | None = utils.get_image_from_struct(data.get("panel"), "thumbnail", 2)
-        self.fanart: str | None = utils.get_image_from_struct(data.get("panel"), "thumbnail", 2)
+        self.thumb: str | None = utils.get_image_from_struct(data, "thumbnail", 2)
+        self.fanart: str | None = utils.get_image_from_struct(data, "thumbnail", 2)
         self.playcount: int = 0
         self.stream_id: str | None = None
 
         try:
             # note that for fetching streams we need a special guid, not the episode_id
             self.stream_id = utils.get_stream_id_from_url(
-                data.get("panel", {}).get("__links__", {}).get("streams", {}).get("href", "")
+                data.get("__links__", {}).get("streams", {}).get("href", "")
             )
 
             # history data has the stream_id at a different location
             if self.stream_id is None:
                 self.stream_id = utils.get_stream_id_from_url(
-                    data.get("panel", {}).get("streams_link")
+                    data.get("streams_link")
                 )
 
             if self.stream_id is None:
@@ -195,38 +195,38 @@ class EpisodeData(Object):
     def __init__(self, data: dict):
         from . import utils
 
-        meta = data.get("panel").get("episode_metadata")
+        meta = data.get("episode_metadata")
 
         self.title: str = utils.format_long_episode_title(meta.get("season_title"), meta.get("episode_number"),
-                                                          data.get("panel").get("title"))
+                                                          data.get("title"))
         self.tvshowtitle: str = meta.get("series_title", "")
         self.duration: int = int(meta.get("duration_ms", 0) / 1000)
         self.playhead: int = data.get("playhead", 0)
         self.season: int = meta.get("season_number", "")
         self.episode: str = meta.get("episode", "")
-        self.episode_id: str | None = data.get("panel", {}).get("id")
+        self.episode_id: str | None = data.get("id")
         self.collection_id: str | None = meta.get("season_id")
         self.series_id: str | None = meta.get("series_id")
-        self.plot: str = data.get("panel", {}).get("description", "")
-        self.plotoutline: str = data.get("panel", {}).get("description", "")
+        self.plot: str = data.get("description", "")
+        self.plotoutline: str = data.get("description", "")
         self.year: str = meta.get("episode_air_date")[:10] if meta.get("episode_air_date") is not None else ""
         self.aired: str = meta.get("episode_air_date")[:10] if meta.get("episode_air_date") is not None else ""
         self.premiered: str = meta.get("episode_air_date")[:10] if meta.get("episode_air_date") is not None else ""
-        self.thumb: str | None = utils.get_image_from_struct(data.get("panel"), "thumbnail", 2)
-        self.fanart: str | None = utils.get_image_from_struct(data.get("panel"), "thumbnail", 2)
+        self.thumb: str | None = utils.get_image_from_struct(data, "thumbnail", 2)
+        self.fanart: str | None = utils.get_image_from_struct(data, "thumbnail", 2)
         self.playcount: int = 0
         self.stream_id: str | None = None
 
         try:
             # note that for fetching streams we need a special guid, not the episode_id
             self.stream_id = utils.get_stream_id_from_url(
-                data.get("panel", {}).get("__links__", {}).get("streams", {}).get("href", "")
+                data.get("__links__", {}).get("streams", {}).get("href", "")
             )
 
             # history data has the stream_id at a different location
             if self.stream_id is None:
                 self.stream_id = utils.get_stream_id_from_url(
-                    data.get("panel", {}).get("streams_link")
+                    data.get("streams_link")
                 )
 
             if self.stream_id is None:
@@ -237,6 +237,23 @@ class EpisodeData(Object):
 
         if self.playhead is not None and self.duration is not None:
             self.playcount = 1 if (int(self.playhead / self.duration * 100)) > 90 else 0
+
+
+# dto
+class SeriesData(Object):
+    def __init__(self, data: dict):
+        from . import utils
+
+        meta = data.get("series_metadata")
+
+        self.title: str = data.get("title")
+        self.tvshowtitle: str = data.get("title")
+        self.series_id: str = data.get("id")
+        self.plot: str = data.get("description")
+        self.plotoutline: str = data.get("description")
+        self.year: str = meta.get("series_launch_year")
+        self.poster: str = utils.get_image_from_struct(data, "poster_tall", 2)
+        self.fanart: str = utils.get_image_from_struct(data, "poster_wide", 2)
 
 
 class CrunchyrollError(Exception):

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -197,6 +197,8 @@ def get_raw_panel_from_dict(item: dict) -> Object:
     result = get_object_data_from_dict(item.get("panel"))
     if result:
         result.playhead = item.get("playhead", 0)
+        if result.duration is not None:
+            result.playcount = 1 if (int(result.playhead / result.duration * 100)) > 90 else 0
     return result
 
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -33,7 +33,8 @@ from datetime import datetime
 import time
 from typing import Dict, Optional, Union
 
-from .model import Args, LoginError, CrunchyrollError
+from . import view
+from .model import Object, EpisodeData, SeriesData, MovieData, Args, LoginError, CrunchyrollError
 
 
 def parse(argv) -> Args:
@@ -113,21 +114,6 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
     return r_json
 
 
-def get_series_data_from_series_ids(args, ids: list, api) -> dict:
-    req = api.make_request(
-        method="GET",
-        url=api.OBJECTS_BY_ID_LIST_ENDPOINT.format(','.join(ids)),
-        params={
-            "locale": args.subtitle,
-            # "preferred_audio_language": ""
-        }
-    )
-    if not req or "error" in req:
-        return {}
-
-    return {item.get("id"): item for item in req.get("data")}
-
-
 def get_stream_id_from_url(url: str) -> Union[str, None]:
     stream_id = re.search('/videos/([^/]+)/streams', url)
     if stream_id is None:
@@ -157,6 +143,113 @@ def get_image_from_struct(item: Dict, image_type: str, depth: int = 2) -> Union[
             return src.get('source')
 
     return None
+
+
+def add_items_to_view(items: list, args, api):
+    series_ids = [
+        item.get("panel").get("episode_metadata").get("series_id")
+        if item.get("panel") and item.get("panel").get("episode_metadata") and item.get("panel").get("episode_metadata").get("series_id")
+        else "0"
+        for item in items
+    ]
+    series_data = get_data_from_object_ids(args, series_ids, api)
+
+    for item in items:
+        try:
+            entry = get_raw_panel_from_dict(item)
+            if not entry:
+                continue
+
+            series_obj = None
+            if entry.series_id:
+                series_obj = series_data.get(entry.series_id)
+                
+            media_info = create_media_info_from_objects_data(entry, series_obj)
+            view.add_item(
+                args,
+                media_info,
+                is_folder=False
+            )
+
+        except Exception:
+            log_error_with_trace(args, "Failed to add item to view: %s" % (json.dumps(item, indent=4)))
+
+
+def get_data_from_object_ids(args, ids: list, api) -> Object:
+    req = api.make_request(
+        method="GET",
+        url=api.OBJECTS_BY_ID_LIST_ENDPOINT.format(','.join(ids)),
+        params={
+            "locale": args.subtitle,
+            # "preferred_audio_language": ""
+        }
+    )
+    if not req or "error" in req:
+        return {}
+
+    return {item.get("id") : get_object_data_from_dict(item) for item in req.get("data")}
+
+
+def get_raw_panel_from_dict(item: dict) -> Object:
+    if not item:
+        return None
+
+    result = get_object_data_from_dict(item.get("panel"))
+    if result:
+        result.playhead = item.get("playhead", 0)
+    return result
+
+
+def get_object_data_from_dict(raw_data: dict) -> Object:
+    if not raw_data or not raw_data.get('type'):
+        return None
+
+    if raw_data.get("type") == "episode":
+        return EpisodeData(raw_data)
+    elif raw_data.get("type") == "series":
+        return SeriesData(raw_data)
+    elif raw_data.get("type") == "movie":
+        return MovieData(raw_data)
+    else:
+        crunchy_log(args, "unhandled index for metadata. %s" % (json.dumps(raw_data, indent=4)),
+                            xbmc.LOGERROR)
+        return None
+
+
+def create_media_info_from_objects_data(entry: Object, series_obj: SeriesData) -> dict:
+    if not entry:
+        return
+
+    poster = ""
+    fanart = ""
+    if series_obj:
+        poster = series_obj.poster
+        fanart = series_obj.fanart
+
+    # add to view
+    return {
+        "title": entry.title,
+        "tvshowtitle": entry.tvshowtitle,
+        "duration": entry.duration,
+        "playcount": entry.playcount,
+        "season": entry.season,
+        "episode": entry.episode,
+        "episode_id": entry.episode_id,
+        "collection_id": entry.collection_id,
+        "series_id": entry.series_id,
+        "plot": entry.plot,
+        "plotoutline": entry.plotoutline,
+        "genre": "",  # no longer available
+        "year": entry.year,
+        "aired": entry.aired,
+        "premiered": entry.premiered,
+        "thumb": entry.thumb,
+        "poster": poster,
+        "fanart": fanart,
+        "stream_id": entry.stream_id,
+        "playhead": entry.playhead,
+        "mode": "videoplay"
+    }
 
 
 def dump(data) -> None:

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -59,7 +59,7 @@ def add_item(
 ) -> xbmcgui.ListItem:
     """Add item to directory listing.
     """
-    li = create_xbmc_item(args, info, True, mediatype)
+    li = create_xbmc_item(args, info, is_folder, mediatype)
 
     # add item to list
     xbmcplugin.addDirectoryItem(handle=int(args.argv[1]),

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -56,18 +56,39 @@ def add_item(
         total_items=0,
         mediatype="video",
         callback: Callable[[xbmcgui.ListItem], None] = None
-):
+) -> xbmcgui.ListItem:
     """Add item to directory listing.
     """
+    li = create_xbmc_item(args, info, True, mediatype)
 
-    # create list item
-    li = xbmcgui.ListItem(label=info["title"])
+    # add item to list
+    xbmcplugin.addDirectoryItem(handle=int(args.argv[1]),
+                                url=li.getPath(),
+                                listitem=li,
+                                isFolder=is_folder,
+                                totalItems=total_items)
 
-    # get infoLabels
-    info_labels = make_info_label(args, info)
+    return li
+
+
+def create_xbmc_item(
+        args,
+        info,
+        is_folder=True,
+        mediatype="video",
+        callback: Callable[[xbmcgui.ListItem], None] = None
+) -> xbmcgui.ListItem:
+    """Create XBMC item for directory listing.
+    """
 
     # get url
     u = build_url(args, info)
+
+    # create list item
+    li = xbmcgui.ListItem(label=info["title"], path=u)
+
+    # get infoLabels
+    info_labels = make_info_label(args, info)
 
     if is_folder:
         # directory
@@ -100,12 +121,7 @@ def add_item(
     if callback:
         callback(li)
 
-    # add item to list
-    xbmcplugin.addDirectoryItem(handle=int(args.argv[1]),
-                                url=u,
-                                listitem=li,
-                                isFolder=is_folder,
-                                totalItems=total_items)
+    return li
 
 
 def quote_value(value):

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -59,7 +59,7 @@ def add_item(
 ) -> xbmcgui.ListItem:
     """Add item to directory listing.
     """
-    li = create_xbmc_item(args, info, is_folder, mediatype)
+    li = create_xbmc_item(args, info, is_folder, mediatype, callback)
 
     # add item to list
     xbmcplugin.addDirectoryItem(handle=int(args.argv[1]),


### PR DESCRIPTION
* I found three times the same loop to add episodes from api to current shown directory. So I move it to a single function called `add_items_to_view` from `controller.py` to `utils.py`.
* Renamed get_series_data_from_series_ids to get_data_from_object_ids since this endpoint is not series specific.
* Removed "panel" reference from ObjectData classes since panel is not provided for some endpoints (e.g. the one called by `get_data_from_object_ids`). The "playhead" is refilled later by wrapping function.
* Always create ObjectData from a wrapping function (`get_object_data_from_dict` or `get_raw_panel_from_dict`) to encourage homogeneous behaviours.
* Extract media_info creation from ObjectData in a specific function called `create_media_info_from_objects_data` to permit usage of its info outside of a shown XBMC list item.