### PR TITLE
chore: Add plugin router

### DIFF
--- a/default.py
+++ b/default.py
@@ -15,13 +15,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import sys
 
 import xbmc
 import xbmcaddon
 
 # plugin constants
-_addon = xbmcaddon.Addon(id=sys.argv[0][9:33])
+_addon = xbmcaddon.Addon(id=re.sub(r"^plugin://([^/]+)/.*$", r"\1", sys.argv[0]))
 _plugin = _addon.getAddonInfo("name")
 _version = _addon.getAddonInfo("version")
 

--- a/default.py
+++ b/default.py
@@ -21,7 +21,7 @@ import xbmc
 import xbmcaddon
 
 # plugin constants
-_addon = xbmcaddon.Addon(id=sys.argv[0][9:-1])
+_addon = xbmcaddon.Addon(id=sys.argv[0][9:33])
 _plugin = _addon.getAddonInfo("name")
 _version = _addon.getAddonInfo("version")
 

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -708,6 +708,10 @@ def view_series(args, api: API):
         view.end_of_directory(args)
         return False
 
+    series_data = utils.get_series_data_from_series_id(args, args.series_id, api)
+    poster = utils.get_image_from_struct(series_data, "poster_tall", 2)
+    fanart = utils.get_image_from_struct(series_data, "poster_wide", 2)
+
     # display media
     for item in req["items"]:
         try:
@@ -732,9 +736,8 @@ def view_series(args, api: API):
                     "aired": None,  # item["created"][:10],
                     "premiered": None,  # item["created"][:10],
                     "status": u"Completed" if item["is_complete"] else u"Continuing",
-                    # TODO
-                    # "thumb": args.thumb,
-                    # "fanart": args.fanart,
+                    "thumb": poster,
+                    "fanart": fanart,
                     "mode": "episodes"
                 },
                 is_folder=True
@@ -785,6 +788,10 @@ def view_episodes(args, api: API):
         }
     )
 
+    series_data = utils.get_series_data_from_series_id(args, args.series_id, api)
+    poster = utils.get_image_from_struct(series_data, "poster_tall", 2)
+    fanart = utils.get_image_from_struct(series_data, "poster_wide", 2)
+
     # display media
     for item in req["items"]:
         try:
@@ -812,10 +819,9 @@ def view_episodes(args, api: API):
                     "plotoutline": item["description"],
                     "aired": item["episode_air_date"][:10],
                     "premiered": item["availability_starts"][:10],  # ???
-                    # TODO
-                    # "poster": args.thumb,
+                    "poster": poster,
                     "thumb": utils.get_image_from_struct(item, "thumbnail", 2),
-                    # "fanart": args.fanart,
+                    "fanart": fanart,
                     "mode": "videoplay",
                     # note that for fetching streams we need a special guid, not the episode_id
                     "stream_id": stream_id,

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -732,8 +732,9 @@ def view_series(args, api: API):
                     "aired": None,  # item["created"][:10],
                     "premiered": None,  # item["created"][:10],
                     "status": u"Completed" if item["is_complete"] else u"Continuing",
-                    "thumb": args.thumb,
-                    "fanart": args.fanart,
+                    # TODO
+                    # "thumb": args.thumb,
+                    # "fanart": args.fanart,
                     "mode": "episodes"
                 },
                 is_folder=True
@@ -811,8 +812,10 @@ def view_episodes(args, api: API):
                     "plotoutline": item["description"],
                     "aired": item["episode_air_date"][:10],
                     "premiered": item["availability_starts"][:10],  # ???
+                    # TODO
+                    # "poster": args.thumb,
                     "thumb": utils.get_image_from_struct(item, "thumbnail", 2),
-                    "fanart": args.fanart,
+                    # "fanart": args.fanart,
                     "mode": "videoplay",
                     # note that for fetching streams we need a special guid, not the episode_id
                     "stream_id": stream_id,

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import re
 
 try:
     from urllib import unquote_plus
@@ -25,6 +26,8 @@ except ImportError:
 from json import dumps
 
 import xbmcaddon
+
+from . import router
 
 
 class Args(object):
@@ -41,7 +44,8 @@ class Args(object):
         self.mode = None
         self.PY2 = sys.version_info[0] == 2  #: True for Python 2
         self._argv = argv
-        self._addonid = self._argv[0][9:-1]
+        self._addonurl = re.sub(r"^(plugin://[^/]+)/.*$", r"\1", argv[0])
+        self._addonid = self._addonurl[9:]
         self._addon = xbmcaddon.Addon(id=self._addonid)
         self._addonname = self._addon.getAddonInfo("name")
         self._cj = None
@@ -53,6 +57,15 @@ class Args(object):
         self.stream_id = None
         self.episode_id = None
         self.duration = None
+
+        self._url = re.sub(r"plugin://[^/]+/", "/", argv[0])
+
+        route_params = router.extract_url_params(self._url)
+        
+        if route_params is not None:
+            for key, value in route_params.items():
+                if value:
+                    setattr(self, key, unquote_plus(value))
 
         for key, value in kwargs.items():
             if value:

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -84,6 +84,10 @@ class Args(object):
         return self._addonid
 
     @property
+    def addonurl(self):
+        return self._addonurl
+
+    @property
     def argv(self):
         return self._argv
 
@@ -98,6 +102,10 @@ class Args(object):
     @property
     def subtitle_fallback(self):
         return self._subtitle_fallback
+
+    @property
+    def url(self):
+        return self._url
 
 
 class Meta(type, metaclass=type("", (type,), {"__str__": lambda _: "~hi"})):

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -15,9 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import Optional, Dict
+from typing import Optional
 
-# An URL is formatted with {parameters}, each parameter are passed to contoller args.
+# A URL is formatted with {parameters}, each parameter are passed to controller args.
 # The "mode" option will be passed to args if set.
 plugin_routes: dict = {
     "main_submenu": {
@@ -92,7 +92,7 @@ def build_path(args: dict) -> Optional[str]:
     """
     Build URL from plugin list item args.
     It will use the route configuration designated by "route" arg.
-    If "route" arg was not set, it will try to find an URL matching the "mode" arg and other available args.
+    If "route" arg was not set, it will try to find a URL matching the "mode" arg and other available args.
     """
     route_name = args.get("route")
     if not route_name:
@@ -113,7 +113,7 @@ def find_route_matching_args(args: dict) -> Optional[str]:
         route_name: extract_params_from_pattern(route_conf.get("url"))
         for route_name, route_conf in routes_matching_mode.items()
     }
-    # Filter out routes that require non existing args
+    # Filter out routes that require non-existing args
     filtered_params = {
         route: params
         for route, params in params_by_route_matching_mode.items()
@@ -147,7 +147,7 @@ def create_path_from_route(route_name: str, args: dict) -> Optional[str]:
     return result
 
 
-def filter_routes_by_mode(searching_mode: str) -> list:
+def filter_routes_by_mode(searching_mode: str) -> dict:
     """
     Filter routes by mode.
     If no route was found for requested mode, return all routes without mode set.

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -33,7 +33,8 @@ plugin_routes: dict = {
     "/series/{series_id}": "series",
     "/series/{series_id}/{collection_id}": "episodes",
     "/series/{series_id}/{collection_id}/offset/{offset}": "episodes",
-    "/video/{series_id}/{episode_id}/{stream_id}": "videoplay"
+    "/video/{series_id}/{episode_id}/{stream_id}": "videoplay",
+    "/video/{episode_id}/{stream_id}": "videoplay"
 }
 
 

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -1,0 +1,95 @@
+
+import re
+
+PARAMETER_ROUTE_MODE: str = "__parameter"
+
+# A route is formatted with {parameters}, its linked value will be the "mode" parameter.
+# If value is PARAMETER_ROUTE_MODE, the "mode" parameter will be taken from the url.
+routes: dict = {
+    "/menu/{mode}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/offset/{offset}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}/offset/{offset}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}/category/{category_filter}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}/category/{category_filter}/offset/{offset}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}/season/{season_filter}": PARAMETER_ROUTE_MODE,
+    "/menu/{mode}/{genre}/season/{season_filter}/offset/{offset}": PARAMETER_ROUTE_MODE,
+    "/series/{series_id}": "series",
+    "/series/{series_id}/{collection_id}": "episodes",
+    "/series/{series_id}/{collection_id}/offset/{offset}": "episodes",
+    "/video/{series_id}/{episode_id}/{stream_id}": "videoplay"
+}
+
+def extract_url_params(url: str) -> dict:
+    for pattern, mode in routes.items():
+        if pattern[0] == "/":
+            pattern = pattern[1:]
+        regexp = "^/?" + pattern.replace("{", "(?P<").replace("}", ">[^/]+)") + "$"
+        result = re.match(regexp, url)
+        if result is not None:
+            resp = result.groupdict()
+            if mode == PARAMETER_ROUTE_MODE:
+                mode = result.group("mode")
+            resp["mode"] = mode
+            return resp
+    
+    return None
+
+def build_path(args: dict) -> str:
+    # Find routes matching mode
+    routes_for_mode = get_matching_routes_with_params_from_mode(args.get("mode"))
+    # Filter routes by existing args
+    routes_for_params = {route: params for route, params in routes_for_mode.items() if check_args_contains_params(args, params)}
+    # Choose the best one
+    param_number: int = 0
+    selected_route: str = None
+    selected_params: list = None
+    for route, params in routes_for_params.items():
+        if len(params) > param_number:
+            param_number = len(params)
+            selected_route = route
+            selected_params = params
+    if not selected_route:
+        return None
+    # Build URL from selected route
+    result = selected_route
+    for param in selected_params:
+        result = result.replace("{%s}" % param, str(args.get(param)))
+    return result
+
+def get_matching_routes_with_params_from_mode(searching_mode: str) -> list:
+    routes = get_matching_routes_from_mode(searching_mode)
+    return {route: get_params_from_route(route) for route in routes}
+
+def get_matching_routes_from_mode(searching_mode: str) -> list:
+    # TODO: Cache it
+    routes_by_mode = {}
+    for pattern, mode in routes.items():
+        if not routes_by_mode.get(mode):
+            routes_by_mode[mode] = []
+        routes_by_mode.get(mode).append(pattern)
+
+    if not routes_by_mode.get(searching_mode):
+        return routes_by_mode.get(PARAMETER_ROUTE_MODE)
+
+    return routes_by_mode.get(searching_mode)
+
+def get_params_from_route(route: str) -> list:
+    # TODO: Cache it
+    params_by_route = {}
+    for pattern, mode in routes.items():
+        params_by_route[pattern] = get_params_from_pattern(pattern)
+
+    if not params_by_route.get(route):
+        return params_by_route.get(PARAMETER_ROUTE_MODE)
+
+    return params_by_route.get(route)
+
+def get_params_from_pattern(pattern: str) -> list:
+    return re.findall(r"\{([^}]+)\}", pattern)
+
+def check_args_contains_params(args: dict, params: list) -> bool:
+    for param in params:
+        if not args.get(param):
+            return False
+    return True

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from typing import Any, Optional
+from typing import Optional, Dict
 
 PARAMETER_ROUTE_MODE: str = "__parameter"
 
@@ -77,7 +77,7 @@ def build_path(args: dict) -> Optional[str]:
     return result
 
 
-def get_matching_routes_with_params_from_mode(searching_mode: str) -> dict[Any, list]:
+def get_matching_routes_with_params_from_mode(searching_mode: str) -> Dict[str, list]:
     routes = get_matching_routes_from_mode(searching_mode)
     return {route: get_params_from_route(route) for route in routes}
 

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -113,8 +113,8 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
     return r_json
 
 
-def get_series_data_from_series_id(args, id: str, api) -> dict:
-    return get_series_data_from_series_ids(args, [id], api).get(id)
+def get_series_data_from_series_id(args, series_id: str, api) -> dict:
+    return get_series_data_from_series_ids(args, [series_id], api).get(series_id)
 
 
 def get_series_data_from_series_ids(args, ids: list, api) -> dict:

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -113,6 +113,10 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
     return r_json
 
 
+def get_series_data_from_series_id(args, id: str, api) -> dict:
+    return get_series_data_from_series_ids(args, [id], api).get(id)
+
+
 def get_series_data_from_series_ids(args, ids: list, api) -> dict:
     req = api.make_request(
         method="GET",

--- a/resources/lib/videoplayer.py
+++ b/resources/lib/videoplayer.py
@@ -19,6 +19,7 @@ import time
 from typing import Optional
 
 import inputstreamhelper
+import requests
 import xbmc
 import xbmcgui
 import xbmcplugin
@@ -237,8 +238,8 @@ class VideoPlayer(Object):
                                 'Content-Type': 'application/json'
                             }
                         )
-                    except ConnectionError:
-                        # catch timeout exception
+                    except requests.exceptions.RequestException:
+                        # catch timeout or any other possible exception
                         utils.crunchy_log(self._args, "Failed to update playhead to crunchyroll")
                         pass
         except RuntimeError:

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -25,6 +25,7 @@ except ImportError:
 import xbmcvfs
 import xbmcgui
 import xbmcplugin
+from . import router
 
 from typing import Callable
 
@@ -119,18 +120,12 @@ def quote_value(value):
 def build_url(args, info):
     """Create url
     """
-    s = ""
-    # step 1 copy new information from info
-    for key, value in list(info.items()):
-        if value:
-            s = s + "&" + key + "=" + quote_value(value)
+    path_args = {}
+    path_args.update(args.__dict__)
+    path_args.update(info)
 
-    # step 2 copy old information from args, but don't append twice
-    for key, value in list(args.__dict__.items()):
-        if value and key in types and not "&" + str(key) + "=" in s:
-            s = s + "&" + key + "=" + quote_value(value)
-
-    return args.argv[0] + "?" + s[1:]
+    result = args._addonurl + router.build_path(path_args)
+    return result
 
 
 def make_info_label(args, info):

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -88,10 +88,10 @@ def add_item(
         cm = []
         if path_params.get("series_id"):
             cm.append((args.addon.getLocalizedString(30045),
-                       "Container.Update(%s/series/%s)" % (args.addonurl, path_params.get("series_id"))))
+                       "Container.Update(%s)" % build_url(args, path_params, "series_view")))
         if path_params.get("collection_id"):
             cm.append((args.addon.getLocalizedString(30046),
-                       "Container.Update(%s/series/%s/%s)" % (args.addonurl, path_params.get("series_id"), path_params.get("collection_id"))))
+                       "Container.Update(%s)" % build_url(args, path_params, "collection_view")))
         if len(cm) > 0:
             li.addContextMenuItems(cm)
 
@@ -121,11 +121,15 @@ def quote_value(value):
     return quote_plus(value)
 
 
-def build_url(args, path_params):
+def build_url(args, path_params, route_name: str=None):
     """Create url
     """
 
-    result = args.addonurl + router.build_path(path_params)
+    if route_name is None:
+        path = router.build_path(path_params)
+    else:
+        path = router.create_path_from_route(route_name, path_params)
+    result = args.addonurl + path
     return result
 
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -124,7 +124,7 @@ def build_url(args, info):
     path_args.update(args.__dict__)
     path_args.update(info)
 
-    result = args._addonurl + router.build_path(path_args)
+    result = args.addonurl + router.build_path(path_args)
     return result
 
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -67,8 +67,12 @@ def add_item(
     # get infoLabels
     info_labels = make_info_label(args, info)
 
+    path_params = {}
+    path_params.update(args.__dict__)
+    path_params.update(info)
+
     # get url
-    u = build_url(args, info)
+    u = build_url(args, path_params)
 
     if is_folder:
         # directory
@@ -82,12 +86,12 @@ def add_item(
 
         # add context menu
         cm = []
-        if u"series_id" in u:
+        if path_params.get("series_id"):
             cm.append((args.addon.getLocalizedString(30045),
-                       "Container.Update(%s)" % re.sub(r"(?<=mode=)[^&]*", "series", u)))
-        if u"collection_id" in u:
+                       "Container.Update(%s/series/%s)" % (args.addonurl, path_params.get("series_id"))))
+        if path_params.get("collection_id"):
             cm.append((args.addon.getLocalizedString(30046),
-                       "Container.Update(%s)" % re.sub(r"(?<=mode=)[^&]*", "episodes", u)))
+                       "Container.Update(%s/series/%s/%s)" % (args.addonurl, path_params.get("series_id"), path_params.get("collection_id"))))
         if len(cm) > 0:
             li.addContextMenuItems(cm)
 
@@ -117,14 +121,11 @@ def quote_value(value):
     return quote_plus(value)
 
 
-def build_url(args, info):
+def build_url(args, path_params):
     """Create url
     """
-    path_args = {}
-    path_args.update(args.__dict__)
-    path_args.update(info)
 
-    result = args.addonurl + router.build_path(path_args)
+    result = args.addonurl + router.build_path(path_params)
     return result
 
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -15,19 +15,18 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-
 try:
     from urllib import quote_plus
 except ImportError:
     from urllib.parse import quote_plus
 
-import xbmcvfs
+from typing import Callable
+
 import xbmcgui
 import xbmcplugin
-from . import router
+import xbmcvfs
 
-from typing import Callable
+from . import router
 
 # keys allowed in setInfo
 types = ["count", "size", "date", "genre", "country", "year", "episode", "season", "sortepisode", "top250", "setid",
@@ -113,7 +112,7 @@ def add_item(
                                 totalItems=total_items)
 
 
-def quote_value(value):
+def quote_value(value) -> str:
     """Quote value depending on python
     """
     if not isinstance(value, str):
@@ -121,7 +120,7 @@ def quote_value(value):
     return quote_plus(value)
 
 
-def build_url(args, path_params, route_name: str=None):
+def build_url(args, path_params, route_name: str = None) -> str:
     """Create url
     """
 
@@ -133,7 +132,7 @@ def build_url(args, path_params, route_name: str=None):
     return result
 
 
-def make_info_label(args, info):
+def make_info_label(args, info) -> dict:
     """Generate info_labels from existing dict
     """
     info_labels = {}

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -119,16 +119,30 @@ def quote_value(value) -> str:
         value = str(value)
     return quote_plus(value)
 
+# Those parameters will be bypassed to URL as additional query_parameters if found in build_url path_params
+whitelist_url_args = [ "duration", "playhead" ]
 
-def build_url(args, path_params, route_name: str = None) -> str:
+def build_url(args, path_params: dict, route_name: str=None) -> str:
     """Create url
     """
 
+    # Get base route
     if route_name is None:
         path = router.build_path(path_params)
     else:
         path = router.create_path_from_route(route_name, path_params)
-    result = args.addonurl + path
+    if path is None:
+        path = "/"
+
+    s = ""
+    # Add whitelisted parameters
+    for key, value in path_params.items():
+        if key in whitelist_url_args and value:
+            s = s + "&" + key + "=" + quote_value(value)
+    if len(s) > 0:
+        s = "?" + s[1:]
+
+    result = args.addonurl + path + s
     return result
 
 


### PR DESCRIPTION
* Ensure behaviour is always the same whenever where the user comes from.
* Avoid strange variable bypass throw pages for unknown reason.
* Permit standard XMBC bookmark usage without outdated data.
* Easier to connect to other extensions (note: I plan to add upnext).

It includes two logics:

* The router logic itself, which is only in `extract_url_params` function:
  * it iterates over routes and return params for the first found matching pattern (which should be the only one)
* An URL build from list item args exposed by `build_path`. It tries to find a route corresponding to passed list item args and format URL to use for this list item. So:
  * it gets routes corresponding to "mode" args (or default routes if no mode corresponding to),
  * it excludes ones which requires param which is not existing in args,
  * it looks for the first matching with the largest parameter count,
  * and it replaces pattern parameter by args values.