### PR TITLE
handle error when loading skip data

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -202,7 +202,7 @@ def log_error_with_trace(args, message, show_notification: bool = True) -> None:
 
     if show_notification:
         xbmcgui.Dialog().notification(
-            '%s Error' % args.addonname,
+            '%s Error' % addon_name,
             'Please check logs for details',
             xbmcgui.NOTIFICATION_ERROR,
             5

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -271,7 +271,7 @@ class VideoStream(Object):
             log_error_with_trace(self.args, "_get_skip_events: error in requesting skip events data from api")
             return None
 
-        if req and "error" in req:
+        if not req or "error" in req:
             crunchy_log(self.args, "_get_skip_events: error in requesting skip events data from api (2)")
             return None
 


### PR DESCRIPTION
Fix the notification to prevent it throwing an error: `AttributeError: 'NoneType' object has no attribute 'addonname'`

And properly check for a failed request aka no response, and short-circuit with an warning.