### PR TITLE
fix: Playheads update failure because of bad request content type

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -206,12 +206,14 @@ class API:
                 "Signature": self.account_data.cms.signature,
                 "Key-Pair-Id": self.account_data.cms.key_pair_id
             })
-        headers.update(self.api_headers)
+        request_headers = {}
+        request_headers.update(self.api_headers)
+        request_headers.update(headers)
 
         r = self.http.request(
             method,
             url,
-            headers=headers,
+            headers=request_headers,
             params=params,
             data=data,
             json=json_data


### PR DESCRIPTION
Content-Type in API is application/x-www-form-urlencoded. This value overrides the Content-Type uses to update playheads.