### PR TITLE
fix: Kodi show error on video when skip data is not found

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -63,6 +63,7 @@ class API:
     SEASONAL_TAGS_ENDPOINT = "https://beta-api.crunchyroll.com/content/v2/discover/seasonal_tags"
     CATEGORIES_ENDPOINT = "https://beta-api.crunchyroll.com/content/v1/tenant_categories"
     SKIP_EVENTS_ENDPOINT = "https://static.crunchyroll.com/skip-events/production/{}.json"  # request w/o auth req.
+    INTRO_V2_ENDPOINT = "https://static.crunchyroll.com/datalab-intro-v2/{}.json"
 
     AUTHORIZATION = "Basic aHJobzlxM2F3dnNrMjJ1LXRzNWE6cHROOURteXRBU2Z6QjZvbXVsSzh6cUxzYTczVE1TY1k="
 
@@ -343,6 +344,9 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
             'data': r.text
         })
         return d
+
+    if not r.ok and r.text[0] != "{":
+        raise CrunchyrollError(f"[{code}] {r.text}")
 
     try:
         r_json: Dict = r.json()

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -272,9 +272,20 @@ class VideoStream(Object):
                 method="GET",
                 url=self.api.SKIP_EVENTS_ENDPOINT.format(episode_id)
             )
-        except requests.exceptions.RequestException:
-            log_error_with_trace(self.args, "_get_skip_events: error in requesting skip events data from api")
-            return None
+        except (requests.exceptions.RequestException, CrunchyrollError):
+            try:
+                # Some streams raise a 403 on SKIP_EVENTS endpoint but skip data are available in INTRO_V2 endpoint
+                intro_req = self.api.make_unauthenticated_request(
+                    method="GET",
+                    url=self.api.INTRO_V2_ENDPOINT.format(episode_id)
+                )
+                req = { "intro": {
+                    "start": intro_req.get("startTime"),
+                    "end": intro_req.get("endTime"),
+                }}
+            except (requests.exceptions.RequestException, CrunchyrollError):
+                log_error_with_trace(self.args, "_get_skip_events: error in requesting skip events data from api")
+                return None
 
         if not req or "error" in req:
             crunchy_log(self.args, "_get_skip_events: error in requesting skip events data from api (2)")


### PR DESCRIPTION
And skip data is not always in the same file.

Please note the official app always request the two static files even if it does not exist…