### PR TITLE
Nexus remove deprecated function calls

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -126,6 +126,14 @@ msgctxt "#30039"
 msgid "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 msgstr "Zeige in der Season-Übersicht eines Anime nur Dubs in Japanisch, deiner CR Sprache oder in einer der von Dir konfigurierten Untertitel-Sprachen"
 
+msgctxt "#30036"
+msgid "Show dub language in Season View"
+msgstr "Zeige die Audio-Sprache in der Season-Übersicht"
+
+msgctxt "#30037"
+msgid "In an anime seasons view, display a dub tag in front of the season name."
+msgstr "Zeige in der Season-Übersicht eines Anime die Audio-Sprache vor dem Titel der Staffel."
+
 
 # Crunchyroll Menue
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -126,6 +126,14 @@ msgctxt "#30039"
 msgid "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 msgstr "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 
+msgctxt "#30036"
+msgid "Show dub language in Season View"
+msgstr "Show dub language in Season View"
+
+msgctxt "#30037"
+msgid "In an anime seasons view, display a dub tag in front of the season name."
+msgstr "In an anime seasons view, display a dub tag in front of the season name."
+
 
 # Crunchyroll Menue
 

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -126,6 +126,14 @@ msgctxt "#30039"
 msgid "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 msgstr "En una vista de temporadas de anime, sólo se muestran los idiomas de audio en japonés, su idioma Crunchyroll o cualquiera de los idiomas de subtítulos configurados."
 
+msgctxt "#30036"
+msgid "Show dub language in Season View"
+msgstr "Mostrar el idioma de doblaje en la vista de temporadas"
+
+msgctxt "#30037"
+msgid "In an anime seasons view, display a dub tag in front of the season name."
+msgstr "En la vista de temporadas de un anime, muestra una etiqueta de doblaje delante del nombre de la temporada."
+
 
 # Crunchyroll Menue
 

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -17,19 +17,19 @@ msgstr ""
 # Crunchyroll Settings
 msgctxt "#30200"
 msgid "Login"
-msgstr ""
+msgstr "Se connecter"
 
 msgctxt "#30210"
 msgid "Languages"
-msgstr ""
+msgstr "Lanagages"
 
 msgctxt "#30220"
 msgid "Playback"
-msgstr ""
+msgstr "Lecture"
 
 msgctxt "#30230"
 msgid "Other"
-msgstr ""
+msgstr "Autre"
 
 msgctxt "#30001"
 msgid "Email"
@@ -53,19 +53,19 @@ msgstr ""
 
 msgctxt "#30010"
 msgid "General"
-msgstr ""
+msgstr "Général"
 
 msgctxt "#30011"
 msgid "Skip intro"
-msgstr ""
+msgstr "Passer l'introduction"
 
 msgctxt "#30012"
 msgid "Skip credits"
-msgstr ""
+msgstr "Passer les crédits"
 
 msgctxt "#30015"
 msgid "Skip"
-msgstr ""
+msgstr "Passer"
 
 msgctxt "#30020"
 msgid "Subtitle Language"
@@ -219,11 +219,11 @@ msgstr "Si la vidéo ne démarre pas, attendez 30 secondes et recommencez."
 
 msgctxt "#30067"
 msgid "Add to queue"
-msgstr "Add to queue"
+msgstr "Ajouter à la file d'attente"
 
 msgctxt "#30068"
 msgid "Remove from queue"
-msgstr "Remove from queue"
+msgstr "Supprimer de la file d'attente"
 
 msgctxt "#30069"
 msgid "Alternative Subtitle Language"
@@ -235,4 +235,4 @@ msgstr "Aucun"
 
 msgctxt "#30071"
 msgid "Added to queue"
-msgstr "Added to queue"
+msgstr "Ajouté à la file d'attente"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -125,6 +125,14 @@ msgctxt "#30039"
 msgid "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 msgstr "Dans une vue de saisons d'anime, n'affichez que les langues audio en japonais, votre langue Crunchyroll ou l'une des langues de sous-titres que vous avez configurées."
 
+msgctxt "#30036"
+msgid "Show dub language in Season View"
+msgstr "Afficher la langue du doublage dans la vue des saisons"
+
+msgctxt "#30037"
+msgid "In an anime seasons view, display a dub tag in front of the season name."
+msgstr "Dans la vue des saisons d'un anime, afficher une étiquette de doublage devant le nom de la saison."
+
 
 # Crunchyroll Menue
 msgctxt "#30040"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -125,6 +125,13 @@ msgctxt "#30039"
 msgid "In an anime seasons view, only display dubs in either Japanese, your CR language or any of your configured subtitle languages."
 msgstr "Em uma exibição de temporadas de anime, exiba apenas os idiomas de áudio em japonês, o idioma Crunchyroll ou qualquer um dos idiomas de legenda configurados."
 
+msgctxt "#30036"
+msgid "Show dub language in Season View"
+msgstr "Mostrar o idioma da dublagem na visualização da temporada"
+
+msgctxt "#30037"
+msgid "In an anime seasons view, display a dub tag in front of the season name."
+msgstr "Em uma visualização de temporadas de anime, exiba uma tag de dublagem na frente do nome da temporada."
 
 
 # Crunchyroll Menue

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -211,11 +211,11 @@ class ListableItem(Object):
 
         li = xbmcgui.ListItem()
         li.setLabel(self.title)
+        li_info = li.getVideoInfoTag()
 
         # if is a playable item, set some things
         if hasattr(self, 'duration'):
             li.setProperty("IsPlayable", "true")
-            li_info = li.getVideoInfoTag()
             # li.setProperty('TotalTime', str(float(getattr(self, 'duration'))))
             li_info.setDuration(int(getattr(self, 'duration')))
             # set resume if not fully watched and playhead > x
@@ -226,7 +226,39 @@ class ListableItem(Object):
                         # li.setProperty('ResumeTime', str(float(getattr(self, 'playhead'))))
                         li_info.setResumePoint(float(getattr(self, 'playhead')), float(getattr(self, 'duration')))
 
-        li.setInfo('video', list_info)
+
+        # new setters with InfoTagVideo instead of li.setInfo()
+        # li.setInfo('video', list_info)
+        li_info.setTitle(list_info.get('title'))
+        li_info.setTvShowTitle(list_info.get('tvshowtitle'))
+        li_info.setSeason(int(list_info.get('season')))
+        # sometimes no explicit episode number is given: ['', 'OVA', 'SP']
+        # sometimes it's a plain number, sometimes it's text
+        if str(list_info.get('episode')).isnumeric():
+            li_info.setEpisode(int(list_info.get('episode')))
+        else:
+            li_info.setEpisode(0)
+        li_info.setPlot(list_info.get('plot'))
+        li_info.setPlotOutline(list_info.get('plotoutline'))
+
+        # playhead -> see setResumePoint above
+        # duration -> see setDuration above
+        li_info.setPlaycount(int(list_info.get('playcount')))
+
+        # season_id -> not part of InfoTagVideo
+        # series_id -> not part of InfoTagVideo
+        # episode_id -> not part of InfoTagVideo
+        # stream_id -> not part of InfoTagVideo
+
+        if list_info.get('year'): # it's unlikely the other dates are given if year is missing
+            li_info.setYear(int(list_info.get('year')[0:3])) # only use first 4 digits in case of date
+            li_info.setFirstAired(list_info.get('aired'))
+            li_info.setPremiered(list_info.get('premiered'))
+
+        li_info.setRating(float(list_info.get('rating')))
+
+        li_info.setMediaType(list_info.get('mediatype'))
+
         li.setArt({
             "thumb": self.thumb or 'DefaultFolder.png',
             'poster': self.poster or self.thumb or 'DefaultFolder.png',
@@ -268,7 +300,7 @@ class PlayableItem(ListableItem):
     Crunchyroll           XBMC
     series                collection
     season                season
-    episode               episode   
+    episode               episode
 """
 
 

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -216,30 +216,28 @@ class ListableItem(Object):
         # if is a playable item, set some things
         if hasattr(self, 'duration'):
             li.setProperty("IsPlayable", "true")
-            # li.setProperty('TotalTime', str(float(getattr(self, 'duration'))))
             li_info.setDuration(int(getattr(self, 'duration')))
             # set resume if not fully watched and playhead > x
             if hasattr(self, 'playcount') and getattr(self, 'playcount') == 0:
                 if hasattr(self, 'playhead') and getattr(self, 'playhead') > 0:
                     resume = int(getattr(self, 'playhead') / getattr(self, 'duration') * 100)
                     if 5 <= resume <= 90:
-                        # li.setProperty('ResumeTime', str(float(getattr(self, 'playhead'))))
                         li_info.setResumePoint(float(getattr(self, 'playhead')), float(getattr(self, 'duration')))
 
 
-        # new setters with InfoTagVideo instead of li.setInfo()
-        # li.setInfo('video', list_info)
         li_info.setTitle(list_info.get('title'))
         li_info.setTvShowTitle(list_info.get('tvshowtitle'))
         li_info.setSeason(int(list_info.get('season')))
-        # sometimes no explicit episode number is given: ['', 'OVA', 'SP']
-        # sometimes it's a plain number, sometimes it's text
+        """ sometimes no explicit episode number is given: ['', 'OVA', 'SP']
+            sometimes it's a plain number, sometimes it's text
+        """
         if str(list_info.get('episode')).isnumeric():
             li_info.setEpisode(int(list_info.get('episode')))
         else:
             li_info.setEpisode(0)
-        li_info.setPlot(list_info.get('plot'))
-        li_info.setPlotOutline(list_info.get('plotoutline'))
+        if list_info.get('plot'): # seasons don't have plots
+            li_info.setPlot(list_info.get('plot'))
+            li_info.setPlotOutline(list_info.get('plotoutline'))
 
         # playhead -> see setResumePoint above
         # duration -> see setDuration above

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -215,13 +215,16 @@ class ListableItem(Object):
         # if is a playable item, set some things
         if hasattr(self, 'duration'):
             li.setProperty("IsPlayable", "true")
-            li.setProperty('TotalTime', str(float(getattr(self, 'duration'))))
+            li_info = li.getVideoInfoTag()
+            # li.setProperty('TotalTime', str(float(getattr(self, 'duration'))))
+            li_info.setDuration(int(getattr(self, 'duration')))
             # set resume if not fully watched and playhead > x
             if hasattr(self, 'playcount') and getattr(self, 'playcount') == 0:
                 if hasattr(self, 'playhead') and getattr(self, 'playhead') > 0:
                     resume = int(getattr(self, 'playhead') / getattr(self, 'duration') * 100)
                     if 5 <= resume <= 90:
-                        li.setProperty('ResumeTime', str(float(getattr(self, 'playhead'))))
+                        # li.setProperty('ResumeTime', str(float(getattr(self, 'playhead'))))
+                        li_info.setResumePoint(float(getattr(self, 'playhead')), float(getattr(self, 'duration')))
 
         li.setInfo('video', list_info)
         li.setArt({
@@ -337,7 +340,7 @@ class SeasonData(ListableItem):
         super().__init__()
 
         self.id = data.get("id")
-        self.title: str = data.get("title")
+        self.title: str = '[' + data.get("audio_locale") + '] ' + data.get("title")
         self.tvshowtitle: str = data.get("title")
         self.series_id: str | None = data.get("series_id")
         self.season_id: str | None = data.get("id")

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -370,7 +370,11 @@ class SeasonData(ListableItem):
         super().__init__()
 
         self.id = data.get("id")
-        self.title: str = '[' + data.get("audio_locale") + '] ' + data.get("title")
+        settings = xbmcaddon.Addon(id=re.sub(r"^plugin://([^/]+)/.*$", r"\1", sys.argv[0])).getSettings()
+        if settings.getBool("show_lang_in_seasons"):
+            self.title: str = '[' + data.get("audio_locale") + '] ' + data.get("title")
+        else:
+            self.title: str = data.get("title")
         self.tvshowtitle: str = data.get("title")
         self.series_id: str | None = data.get("series_id")
         self.season_id: str | None = data.get("id")

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -293,7 +293,5 @@ def highlight_list_item_title(list_item: xbmcgui.ListItem):
 
         Used to highlight that item is already on watchlist
     """
-    # new setter with InfoTagVideo instead of li.setInfo()
-    # list_item.setInfo('video', {'title': '[COLOR orange]' + list_item.getLabel() + '[/COLOR]'})
     li_info = list_item.getVideoInfoTag()
     li_info.setTitle('[COLOR orange]' + list_item.getLabel() + '[/COLOR]')

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -293,4 +293,7 @@ def highlight_list_item_title(list_item: xbmcgui.ListItem):
 
         Used to highlight that item is already on watchlist
     """
-    list_item.setInfo('video', {'title': '[COLOR orange]' + list_item.getLabel() + '[/COLOR]'})
+    # new setter with InfoTagVideo instead of li.setInfo()
+    # list_item.setInfo('video', {'title': '[COLOR orange]' + list_item.getLabel() + '[/COLOR]'})
+    li_info = list_item.getVideoInfoTag()
+    li_info.setTitle('[COLOR orange]' + list_item.getLabel() + '[/COLOR]')

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -89,18 +89,12 @@ def add_item(
 
     if is_folder:
         # directory
-        # new setters with InfoTagVideo instead of li.setInfo()
-        # info_labels["mediatype"] = "tvshow"
-        # li.setInfo(mediatype, info_labels)
         li_info.setTitle(info_labels.get('title'))
         if info_labels.get('genre'):
             li_info.setGenres([info_labels.get('genre')])
         li_info.setMediaType('tvshow')
     else:
         # playable video
-        # new setters with InfoTagVideo instead of li.setInfo()
-        # info_labels["mediatype"] = "episode"
-        # li.setInfo(mediatype, info_labels)
         li.setProperty("IsPlayable", "true")
         li_info.setTitle(info_labels.get('title'))
         if info_labels.get('genre'):

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -82,19 +82,30 @@ def add_item(
 
     # create list item
     li = xbmcgui.ListItem(label=info["title"], path=u)
+    li_info = li.getVideoInfoTag()
 
     # get infoLabels
     info_labels = make_info_label(args, info)
 
     if is_folder:
         # directory
-        info_labels["mediatype"] = "tvshow"
-        li.setInfo(mediatype, info_labels)
+        # new setters with InfoTagVideo instead of li.setInfo()
+        # info_labels["mediatype"] = "tvshow"
+        # li.setInfo(mediatype, info_labels)
+        li_info.setTitle(info_labels.get('title'))
+        if info_labels.get('genre'):
+            li_info.setGenres([info_labels.get('genre')])
+        li_info.setMediaType('tvshow')
     else:
         # playable video
-        info_labels["mediatype"] = "episode"
-        li.setInfo(mediatype, info_labels)
+        # new setters with InfoTagVideo instead of li.setInfo()
+        # info_labels["mediatype"] = "episode"
+        # li.setInfo(mediatype, info_labels)
         li.setProperty("IsPlayable", "true")
+        li_info.setTitle(info_labels.get('title'))
+        if info_labels.get('genre'):
+            li_info.setGenres([info_labels.get('genre')])
+        li_info.setMediaType('episode')
 
         # add context menu to jump to seasons xor episodes
         # @todo: this only makes sense in some very specific places, we need a way to handle these better.

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -99,6 +99,12 @@
                     <default>true</default>
                     <control type="toggle"/>
                 </setting>
+
+                <setting id="show_lang_in_seasons" type="boolean" label="30036" help="30037">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
             </group>
         </category>
         <category id="playback_options" label="30220" help="">


### PR DESCRIPTION
I removed deprecated function calls (`ListItem.setInfo()` and parts of `ListItem.setProperty()`) while trying to catch all possible errors with this. This makes the kodi log file for debugging a little cleaner.

For more info on deprecated functions see:
- https://alwinesch.github.io/group__python__xbmcgui__listitem.html#ga96f1976952584c91e6d59c310ce86a25
- https://alwinesch.github.io/group__python__xbmcgui__listitem.html#ga0f1e91e1d5aa61d8dd0eac90e8edbf18
- https://alwinesch.github.io/group__python___info_tag_video.html

Also added a language block in front of seasons that can be enabled in settings. (Disabled by default. Probably not the cleanest way to do that, but it works.) 