### PR TITLE
Option to use short titles in episodes lists

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -68,6 +68,10 @@ msgctxt "#30015"
 msgid "Skip"
 msgstr "Überspringen"
 
+msgctxt "#30018"
+msgid "Use short titles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Untertitel Sprache"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -67,6 +67,10 @@ msgctxt "#30015"
 msgid "Skip"
 msgstr ""
 
+msgctxt "#30018"
+msgid "Use short titles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -67,6 +67,10 @@ msgctxt "#30015"
 msgid "Skip"
 msgstr "Saltar"
 
+msgctxt "#30018"
+msgid "Use short titles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Lenguaje de los subtítulos"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -67,6 +67,10 @@ msgctxt "#30015"
 msgid "Skip"
 msgstr "Passer"
 
+msgctxt "#30018"
+msgid "Use short titles"
+msgstr ""
+
 msgctxt "#30020"
 msgid "Subtitle Language"
 msgstr "Language des sous titres"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -21,15 +21,15 @@ msgstr ""
 
 msgctxt "#30210"
 msgid "Languages"
-msgstr ""
+msgstr "Idioma"
 
 msgctxt "#30220"
 msgid "Playback"
-msgstr ""
+msgstr "Reprodução"
 
 msgctxt "#30230"
 msgid "Other"
-msgstr ""
+msgstr "Outros"
 
 msgctxt "#30001"
 msgid "Username"
@@ -53,23 +53,27 @@ msgstr ""
 
 msgctxt "#30010"
 msgid "General"
-msgstr ""
+msgstr "Geral"
 
 msgctxt "#30011"
 msgid "Skip intro"
-msgstr ""
+msgstr "Pular abertura"
 
 msgctxt "#30012"
 msgid "Skip credits"
-msgstr ""
+msgstr "Pular créditos"
 
 msgctxt "#30015"
 msgid "Skip"
 msgstr ""
 
+msgctxt "#30018"
+msgid "Use short titles"
+msgstr "Usar títulos curtos"
+
 msgctxt "#30020"
 msgid "Subtitle Language"
-msgstr "Linguagem da legenda"
+msgstr "Idioma da legenda"
 
 msgctxt "#30021"
 msgid "English"
@@ -164,7 +168,7 @@ msgstr "Retomar"
 
 msgctxt "#30049"
 msgid "Crunchylists"
-msgstr ""
+msgstr "Crunchylistas"
 
 msgctxt "#30050"
 msgid "Anime"
@@ -237,15 +241,15 @@ msgstr "Se o vídeo não iniciar, aguarde 30 segundos e tente novamente."
 
 msgctxt "#30067"
 msgid "Add to queue"
-msgstr "Add to queue"
+msgstr "Adicionar à fila"
 
 msgctxt "#30068"
 msgid "Remove from queue"
-msgstr "Remove from queue"
+msgstr "Remover da fila"
 
 msgctxt "#30069"
 msgid "Alternative Subtitle Language"
-msgstr "Linguagem de Legendas Alternativa"
+msgstr "Idioma de Legendas Alternativa"
 
 msgctxt "#30070"
 msgid "None"
@@ -253,8 +257,8 @@ msgstr "Sem Legendas"
 
 msgctxt "#30071"
 msgid "Added to queue"
-msgstr "Added to queue"
+msgstr "Adicionado à fila"
 
 msgctxt "#30080"
 msgid "There are to many active streams. Please try again later."
-msgstr ""
+msgstr "Muitas streams ativas. Por favor, tente mais tarde"

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -388,6 +388,7 @@ class SeasonData(ListableItem):
 
 
 # dto
+    
 class EpisodeData(PlayableItem):
     """ A single Episode of a Season of a Series """
 
@@ -395,12 +396,19 @@ class EpisodeData(PlayableItem):
         super().__init__()
         from . import utils
 
+        args = utils.parse(sys.argv)
         panel = data.get('panel') or data
         meta = panel.get("episode_metadata") or panel
 
         self.id = panel.get("id")
-        self.title: str = utils.format_long_episode_title(meta.get("season_title"), meta.get("episode_number"),
+        
+        if args.addon.getSetting("enable_short_title") == "true":
+            self.title: str = utils.format_short_episode_title(meta.get("episode_number"),
                                                           panel.get("title"))
+        else:
+            self.title: str = utils.format_long_episode_title(meta.get("season_title"), meta.get("episode_number"),
+                                                          panel.get("title"))
+        
         self.tvshowtitle: str = meta.get("series_title", "")
         self.duration: int = int(meta.get("duration_ms", 0) / 1000)
         self.playhead: int = data.get("playhead", 0)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -276,8 +276,8 @@ def format_long_episode_title(season_title: str, episode_number: str, title: str
     return season_title + " #" + str(episode_number) + " - " + title
 
 
-def format_short_episode_title(season_number: int, episode_number: str, title: str):
-    return (str(season_number) + "x" if season_number else "") + two_digits(episode_number) + ". " + title
+def format_short_episode_title(episode_number: str, title: str):
+    return two_digits(episode_number) + " - " + title
 
 
 def two_digits(n):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -123,6 +123,11 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
+				<setting id="enable_short_title" type="boolean" label="30018" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
             </group>
         </category>
     </section>


### PR DESCRIPTION
Hello, 
There's a thing that I do every new release, is to change how the addon display the episodes titles, because its shows like "(Anime title) (epnumber) (ep title)". Its annoys me, because I already got into the anime folder > season folder, so I know whats the anime name, sometimes with big titles you need to wait the name scrool to found the episode number and title.
![Captura de tela 2024-04-09 130052](https://github.com/smirgol/plugin.video.crunchyroll/assets/23280011/25cee7c6-821e-4fed-8cdb-eff2b5ee18bf)

So I though thats would be nice to add an option to use short titles:
![Captura de tela 2024-04-09 130144](https://github.com/smirgol/plugin.video.crunchyroll/assets/23280011/5fb6cfeb-b8ae-482d-9941-223b1e5558f5)

If you use the resume folder its become a mess with list view, but its okay with another views like infowall
![ss3](https://github.com/smirgol/plugin.video.crunchyroll/assets/23280011/3401d78f-c570-441b-93b1-e819cd808813)

Also works "well" with others skins, in the embuary the episode number repeats because how the skin shows titles, but I think is better than the long title starting with the anime name
![ss4](https://github.com/smirgol/plugin.video.crunchyroll/assets/23280011/64458da5-a672-4b8a-bb3a-8263b817f839)

And I added some missings thing in the pt-br language file.
Fell free to add this option or not. Sorry if a did a mess to read the settings in model.py, Im not familiar with py or kodi addons progamming.