### PR TITLE
Local Playcount without online Sync.

### DIFF
--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -92,7 +92,7 @@ def show_queue():
         options=view.OPT_CTX_SEASONS | view.OPT_CTX_EPISODES
     )
 
-    view.end_of_directory("episodes")
+    view.end_of_directory("episodes", cache_to_disc=False)
     return True
 
 
@@ -196,7 +196,7 @@ def show_history():
             is_folder=True
         )
 
-    view.end_of_directory("episodes")
+    view.end_of_directory("episodes", cache_to_disc=False)
     return True
 
 
@@ -240,7 +240,7 @@ def show_resume_episodes():
             is_folder=True
         )
 
-    view.end_of_directory("episodes")
+    view.end_of_directory("episodes", cache_to_disc=False)
 
     return True
 
@@ -482,7 +482,7 @@ def view_episodes():
         options=view.OPT_NO_SEASON_TITLE
     )
 
-    view.end_of_directory("episodes")
+    view.end_of_directory("episodes", cache_to_disc=False)
     return True
 
 

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -266,6 +266,10 @@ class ListableItem(Object):
         # filter out items not known to kodi
         list_info = {key: info[key] for key in types if key in info}
 
+        # only allow to overwrite the local playcount if we sync the playtime with the server
+        if G.args.addon.getSetting("sync_playtime") == "true" and hasattr(self, 'playcount'):
+            list_info["playcount"] = getattr(self, 'playcount')
+
         li = xbmcgui.ListItem()
         li.setLabel(self.title)
 


### PR DESCRIPTION
Kodi actually handles the playcount out of the box, but the addon did always overwrite this information.

Change:
* If the "play time progress" sync is disabled, don't overwrite the local playcount information.
* Removed the obsolete extra parameters in the list item URL: The local Kodi playcount system only works, if the URL of the items in the list view and the URL that is send to the player are the same.
* Disabled cacheToDisk for episode lists: for some reason the local playcount is not cached which breaks the usage in the Favourites list when opening an episodes list twice

This might be a simple solution for
Use kodi database for progress when sync with crunchyroll is disabled #48 