### PR TITLE
Fixed a race condition when handling skipping

### DIFF
--- a/resources/lib/videoplayer.py
+++ b/resources/lib/videoplayer.py
@@ -55,9 +55,9 @@ class VideoPlayer(Object):
         self._prepare_and_start_playback()
 
         self._handle_update_playhead()
-        self._handle_skipping()
         if not self._wait_for_playback_started(10):
             utils.crunchy_log('Timeout reached, video did not start playback in 10 seconds', xbmc.LOGERROR)
+        self._handle_skipping()
 
     def is_playing(self) -> bool:
         """ Returns true if playback is running. Note that it also returns true when paused. """


### PR DESCRIPTION
With certain options, the start_playback returns before the is_playback returns true, which makes skip handler thread to stop even before the playback has started.

Fix: wait for the is_playback to be true before starting the skip handling thread (with a timeout)
This is similar to the previous playback start fix.
