### PR TITLE
A submenu has been added to add series or movies to the Kodi library.…

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,6 +4,7 @@
         <import addon="xbmc.python" version="3.0.1"/>
         <import addon="script.module.inputstreamhelper" version="0.3.3"/>
         <import addon="script.module.requests" version="2.31.0"/>
+        <import addon="script.module.xmltodict"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -186,6 +186,10 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Fortsetzen"
 
+msgctxt "#30048"
+msgid "Add to library"
+msgstr ""
+
 msgctxt "#30049"
 msgid "Crunchylists"
 msgstr "Crunchylists"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -186,7 +186,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr ""
 
-# 30048 free
+msgctxt "#30048"
+msgid "Add to library"
+msgstr ""
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -185,7 +185,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Reanudar"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Add to library"
+msgstr "Añadir a la libreria"
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -184,7 +184,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Reprendre"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Add to library"
+msgstr ""
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -184,7 +184,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Retomar"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Add to library"
+msgstr ""
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -50,7 +50,7 @@ class API:
     STREAMS_ENDPOINT = "https://beta-api.crunchyroll.com/cms/v2{}/videos/{}/streams"
     STREAMS_ENDPOINT_DRM = "https://cr-play-service.prd.crunchyrollsvc.com/v1/{}/android/phone/play"
     STREAMS_ENDPOINT_CLEAR_STREAM = "https://cr-play-service.prd.crunchyrollsvc.com/v1/token/{}/{}"
-    # SERIES_ENDPOINT = "https://beta-api.crunchyroll.com/cms/v2{}/series/{}"
+    SERIES_ENDPOINT = "https://beta-api.crunchyroll.com/content/v2/cms/series/{}"
     SEASONS_ENDPOINT = "https://beta-api.crunchyroll.com/cms/v2{}/seasons"
     EPISODES_ENDPOINT = "https://beta-api.crunchyroll.com/cms/v2{}/episodes"
     OBJECTS_BY_ID_LIST_ENDPOINT = "https://beta-api.crunchyroll.com/content/v2/cms/objects/{}"

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -30,6 +30,7 @@ from .globals import G
 from .model import CrunchyrollError, ProfileData
 from .utils import get_listables_from_response
 from .videoplayer import VideoPlayer
+import xmltodict
 
 
 def show_profiles():
@@ -647,3 +648,247 @@ def crunchylists_item():
     view.end_of_directory("tvshows")
 
     return None
+
+def get_info_series():
+    # api request
+    req = G.api.make_request(
+        method="GET",
+        url=G.api.SERIES_ENDPOINT.format(G.args.get_arg('series_id')),
+        params={
+            "locale": G.args.subtitle,
+            "preferred_audio_language": G.api.account_data.default_audio_language
+        }
+    )
+    
+    # check for error
+    if not req or "error" in req:
+        return None
+    
+    
+    return req
+def get_info_season():
+    """ get information all seasons/arcs of an anime
+    """
+    # api request
+    req = G.api.make_request(
+        method="GET",
+        url=G.api.SEASONS_ENDPOINT.format(G.api.account_data.cms.bucket),
+        params={
+            "locale": G.args.subtitle,
+            "series_id": G.args.get_arg('series_id'),
+            "preferred_audio_language": G.api.account_data.default_audio_language,
+            "force_locale": ""
+        }
+    )
+
+    # check for error
+    if not req or "error" in req:
+        return None
+
+    return req
+
+def get_info_episodes(season_id):
+    """ get all episodes of season
+    """
+    # api request
+    req = G.api.make_request(
+        method="GET",
+        url=G.api.EPISODES_ENDPOINT.format(G.api.account_data.cms.bucket),
+        params={
+            "locale": G.args.subtitle,
+            "season_id": season_id
+        }
+    )
+
+    # check for error
+    if not req or "error" in req:
+        return None
+
+    return req
+
+
+def add_series_library():
+    # Initialize progress dialog
+    pDialog = xbmcgui.DialogProgress()
+    pDialog.create("Processing...", "Getting information from the series")
+    series = get_info_series()
+    
+    # check for error
+    if series == None:
+        pDialog.close()
+
+        xbmcgui.Dialog().notification(
+            G.args.addon_name,
+            G.args.addon.getLocalizedString(30061),
+            xbmcgui.NOTIFICATION_ERROR
+        )
+        return False
+        
+    # write file content    
+    file_path_tv_show = f"special://profile/addon_data/plugin.video.crunchyroll/video-library/crunchyroll-tv-shows/{series['data'][0]['slug_title']}"
+    
+    if not xbmcvfs.exists(file_path_tv_show):
+        xbmcvfs.mkdir(file_path_tv_show)
+
+    poster_tall_images = series["data"][0]["images"]["poster_tall"][0]
+    poster_tall_images = max(poster_tall_images, key=lambda x: x["width"])
+    
+    poster_wide_images = series["data"][0]["images"]["poster_wide"][0]
+    poster_wide_images = max(poster_wide_images, key=lambda x: x["width"])
+    
+    tv_show = {
+        "tvshow": {
+            "title": series["data"][0]["title"],
+            "plot": series["data"][0]["description"],
+            "thumb": [
+                {
+                    "@aspect": "poster",
+                    "#text": poster_tall_images["source"]
+                },
+                {
+                    "@aspect": "banner",
+                    "#text": poster_wide_images["source"]
+                }
+            ],
+            "episode": series["data"][0]["episode_count"],
+            "season": series["data"][0]["season_count"],
+            "namedseason": [],
+        }
+    }
+    
+    with xbmcvfs.File(f"{file_path_tv_show}/tvshow.nfo", 'w') as f:
+        f.write(xmltodict.unparse(tv_show, pretty=True))
+    
+    seasons = get_info_season()
+    total_seasons = len(seasons["items"])
+    
+    for ids, s in enumerate(seasons["items"]):
+        # filter series items based on language settings
+        if not utils.filter_seasons(s):
+            continue
+        
+        # add season name
+        tv_show["tvshow"]["namedseason"].append({
+            "@number": s["season_number"],
+            "#text": s["title"]
+        })
+        
+        with xbmcvfs.File(f"{file_path_tv_show}/tvshow.nfo", 'w') as f:
+            f.write(xmltodict.unparse(tv_show, pretty=True))
+        
+        # get episodes information    
+        episodes = get_info_episodes(s["id"])
+        percent = int(((ids + 1) / total_seasons) * 100)  # Ensuring 100% on last season
+    
+        for e in episodes['items']:
+            pDialog.update(percent, f"Processing Season Episodes: {ids + 1} of {total_seasons}:\n {e['title']}")
+            
+            item_type = e.get('panel', {}).get('type') or e.get('type') or e.get('__class__')
+            
+            if item_type == 'movie' or e["episode_number"] == None:
+                # create folder movie    
+                file_path_movies = f"special://profile/addon_data/plugin.video.crunchyroll/video-library/crunchyroll-movies/{e['slug_title']}"
+                
+                if not xbmcvfs.exists(file_path_movies):
+                    xbmcvfs.mkdir(file_path_movies)
+                    
+                # create strm file for movie
+                file_name = f"{file_path_movies}/{e['title']}"
+                panel = e.get('panel') or e
+                stream = utils.get_stream_id_from_item(panel)
+                
+                with xbmcvfs.File(f"{file_name}.strm", 'w') as f:
+                    f.write(f"plugin://plugin.video.crunchyroll/video/{G.args.get_arg('series_id')}/{e['id']}/{stream}")
+                
+                # create mfo file for movie   
+                thumbnail = e["images"]["thumbnail"][0]
+                thumbnail = max(thumbnail, key=lambda x: x["width"])
+                movie = {
+                    "movie": {
+                        "title": f'{e["season_title"]} {e["title"]}',
+                        "plot": e["description"],
+                        "thumb": [
+                            {
+                                "@aspect": "poster",
+                                "#text": poster_tall_images["source"]
+                            },
+                            {
+                                "@aspect": "banner",
+                                "#text": poster_wide_images["source"]
+                            },
+                        ],
+                        "fanart": {
+                            "thumb": {
+                                "@aspect": "thumb",
+                                "@preview": thumbnail["source"],
+                                "#text": thumbnail["source"]
+                            }
+                        },
+                        "fileinfo": {
+                            "streamdetails": {
+                                "video": {
+                                    "durationinseconds": e["duration_ms"] / 1000
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                
+                with xbmcvfs.File(f"{file_name}.nfo", 'w') as f:
+                    f.write(xmltodict.unparse(movie, pretty=True))
+            elif item_type == 'episode':
+                
+                # create folder season
+                file_path = f"{file_path_tv_show}/{s['title']}"
+                
+                if not xbmcvfs.exists(file_path):
+                    xbmcvfs.mkdir(file_path)
+            
+                # create strm file from episode
+                file_path = f"{file_path_tv_show}/{s['title']}"
+                file_name = f"{file_path}/S{e['season_number']}E{e['episode_number']}"
+                panel = e.get('panel') or e
+                stream = utils.get_stream_id_from_item(panel)
+                
+                with xbmcvfs.File(f"{file_name}.strm", 'w') as f:
+                    f.write(f"plugin://plugin.video.crunchyroll/video/{G.args.get_arg('series_id')}/{e['id']}/{stream}")
+                
+                # create mfo file from episode   
+                thumbnail = e["images"]["thumbnail"][0]
+                thumbnail = max(thumbnail, key=lambda x: x["width"])
+                episode = {
+                    "episodedetails": {
+                        "title": f'{e["season_title"]} {e["title"]}',
+                        "plot": e["description"],
+                        "thumb": {
+                            "@aspect": "thumb",
+                            "@preview": thumbnail["source"],
+                            "#text": thumbnail["source"]
+                        },
+                        "season": e["season_number"],
+                        "episode": e["episode_number"],
+                        "aired": e["episode_air_date"],
+                        "fileinfo": {
+                            "streamdetails": {
+                                "video": {
+                                    "durationinseconds": e["duration_ms"] / 1000
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                
+                with xbmcvfs.File(f"{file_name}.nfo", 'w') as f:
+                    f.write(xmltodict.unparse(episode, pretty=True))
+            else:
+                utils.crunchy_log(
+                    "get_listables_from_response | unhandled index for metadata. %s" % (json.dumps(e, indent=4)),
+                    xbmc.LOGERROR
+                )
+                continue
+    pDialog.close()
+    xbmcgui.Dialog().notification('Addon configurado','Episodes Added to the Library', xbmcgui.NOTIFICATION_INFO)
+    xbmc.executebuiltin(f'UpdateLibrary(video)')
+    return True

--- a/resources/lib/crunchyroll.py
+++ b/resources/lib/crunchyroll.py
@@ -173,6 +173,8 @@ def check_mode():
         controller.crunchylists_item()
     elif mode == 'profiles_list':
         controller.show_profiles()
+    elif mode ==  "add_library":
+        controller.add_series_library()
     else:
         # unknown mode
         utils.crunchy_log("Failed in check_mode '%s'" % str(mode), xbmc.LOGERROR)

--- a/resources/lib/router.py
+++ b/resources/lib/router.py
@@ -73,6 +73,10 @@ plugin_routes: dict = {
         "url": "/profiles/{mode}",
         "mode": "profiles_list"
     },
+    "add_serie_library": {
+        "url": "/add_library/{series_id}",
+        "mode": "add_library"
+    },
 }
 
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -295,6 +295,10 @@ def add_listables(
             route = (G.args.addonurl +
                      router.create_path_from_route('series_view', {'series_id': listable.series_id}))
             cm.append((G.args.addon.getLocalizedString(30045), "Container.Update(%s)" % route))
+            
+            route = (G.args.addonurl +
+                     router.create_path_from_route('add_serie_library', {'series_id': listable.series_id}))
+            cm.append((G.args.addon.getLocalizedString(30048), "RunPlugin(%s)" % route))
 
         if options & OPT_CTX_EPISODES and hasattr(listable, 'season_id') and getattr(listable, 'season_id') is not None:
             route = (G.args.addonurl +


### PR DESCRIPTION
… It is necessary to configure the following paths:

    For movies: special://profile/addon_data/plugin.video.crunchyroll/video-library/crunchyroll-movies/. Make sure the content is set to 'movies' and that the option for movies to be in separate folders, matching the name of each movie, is checked.

    For series: special://profile/addon_data/plugin.video.crunchyroll/video-library/crunchyroll-tv-shows/. In this case, the content should be set to 'series' and local information should be used only.

![2025-02-16_18-15](https://github.com/user-attachments/assets/3169715e-3317-4e23-ac16-3fa2af7c559e)
![2025-02-16_18-14](https://github.com/user-attachments/assets/5d5daa21-e089-4428-aac7-c2771c5cf039)
