### PR TITLE
feat: Implements new Crunchyroll artworks as expected by Kodi

### DIFF
--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -289,16 +289,23 @@ class ListableItem(Object):
                         li.setProperty('ResumeTime', str(float(getattr(self, 'playhead'))))
 
         li.setInfo('video', list_info)
-        li.setArt({
-            "thumb": self.thumb or 'DefaultFolder.png',
-            "landscape": self.landscape or self.thumb or 'DefaultFolder.png',
-            'poster': self.poster or self.thumb or 'DefaultFolder.png',
-            'banner': self.thumb or 'DefaultFolder.png',
-            'fanart': self.fanart or xbmcvfs.translatePath(G.args.addon.getAddonInfo('fanart')),
-            'clearlogo': self.clearlogo,
-            'clearart': self.clearart,
-            'icon': self.thumb or 'DefaultFolder.png'
-        })
+        artworks = {}
+        # Do not add an artwork if it is empty here,
+        # otherwise, you will override the inherited one (from series or season for example).
+        if self.thumb is not None:
+            artworks["thumb"] = self.thumb
+        if self.poster is not None:
+            artworks["poster"] = self.poster
+            artworks["banner"] = self.poster
+        if self.fanart is not None:
+            artworks["fanart"] = self.fanart
+        if self.landscape is not None:
+            artworks["landscape"] = self.landscape
+        if self.clearart is not None:
+            artworks["clearart"] = self.clearart
+        if self.clearlogo is not None:
+            artworks["clearlogo"] = self.clearlogo
+        li.setArt(artworks)
 
         return li
 

--- a/resources/lib/model.py
+++ b/resources/lib/model.py
@@ -248,9 +248,12 @@ class ListableItem(Object):
         self.title: str | None = None
         self.title_unformatted: str | None = None
         self.thumb: str | None = None
+        self.landscape: str | None = None
         self.fanart: str | None = None
         self.poster: str | None = None
         self.banner: str | None = None
+        self.clearlogo: str | None = None
+        self.clearart: str | None = None
 
     @abstractmethod
     def get_info(self) -> Dict:
@@ -288,9 +291,12 @@ class ListableItem(Object):
         li.setInfo('video', list_info)
         li.setArt({
             "thumb": self.thumb or 'DefaultFolder.png',
+            "landscape": self.landscape or self.thumb or 'DefaultFolder.png',
             'poster': self.poster or self.thumb or 'DefaultFolder.png',
             'banner': self.thumb or 'DefaultFolder.png',
             'fanart': self.fanart or xbmcvfs.translatePath(G.args.addon.getAddonInfo('fanart')),
+            'clearlogo': self.clearlogo,
+            'clearart': self.clearart,
             'icon': self.thumb or 'DefaultFolder.png'
         })
 
@@ -355,8 +361,11 @@ class SeriesData(ListableItem):
         self.episode: int = meta.get('episode_count')
         self.season: int = meta.get('season_count')
 
-        self.thumb: str | None = utils.get_img_from_struct(panel, "poster_tall", 2)
-        self.fanart: str | None = utils.get_img_from_struct(panel, "poster_wide", 2)
+        self.thumb: str | None = utils.get_img_from_struct(panel, "poster_wide", 2)
+        self.landscape: str | None = utils.get_img_from_struct(panel, "poster_wide", 2)
+        self.fanart: str | None = utils.infer_img_from_id(self.id, "backdrop_wide")
+        self.clearlogo: str | None = utils.infer_img_from_id(self.id, "title_logo")
+        self.clearart: str | None = utils.infer_img_from_id(self.id, "title_logo")
         self.poster: str | None = utils.get_img_from_struct(panel, "poster_tall", 2)
         self.banner: str | None = None
         self.rating: int = 0
@@ -413,9 +422,12 @@ class SeasonData(ListableItem):
         self.episode: int = 0  # @todo we want to display that, but it's not in the data
         self.season: int = data.get('season_number')
         self.thumb: str | None = None
+        self.landscape: str | None = None
         self.fanart: str | None = None
         self.poster: str | None = None
         self.banner: str | None = None
+        self.clearlogo: str | None = None
+        self.clearart: str | None = None
         self.rating: int = 0
         self.playcount: int = 1 if data.get('is_complete') == 'true' else 0
 
@@ -482,9 +494,12 @@ class EpisodeData(PlayableItem):
         self.aired: str = meta.get("episode_air_date")[:10] if meta.get("episode_air_date") is not None else ""
         self.premiered: str = meta.get("episode_air_date")[:10] if meta.get("episode_air_date") is not None else ""
         self.thumb: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
+        self.landscape: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
         self.fanart: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
         self.poster: str | None = None
         self.banner: str | None = None
+        self.clearlogo: str | None = None
+        self.clearart: str | None = None
         self.rating: int = 0
         self.playcount: int = 0
         self.stream_id: str | None = utils.get_stream_id_from_item(panel)
@@ -554,9 +569,12 @@ class MovieData(PlayableItem):
         self.premiered: str = meta.get("premium_available_date")[:10] if meta.get(
             "premium_available_date") is not None else ""
         self.thumb: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
+        self.landscape: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
         self.fanart: str | None = utils.get_img_from_struct(panel, "thumbnail", 2)
         self.poster: str | None = None
         self.banner: str | None = None
+        self.clearlogo: str | None = None
+        self.clearart: str | None = None
         self.rating: int = 0
         self.playcount: int = 0
         self.stream_id: str | None = utils.get_stream_id_from_item(panel)

--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -194,6 +194,18 @@ def get_img_from_struct(item: Dict, image_type: str, depth: int = 2) -> Union[st
     return None
 
 
+def infer_img_from_id(id: str, image_type: str) -> Union[str, None]:
+    """ get image URL from listable struct data """
+
+    match image_type:
+        case "backdrop_wide":
+            return f"https://imgsrv.crunchyroll.com/cdn-cgi/image/fit=cover,format=auto,quality=85,width=3840,height=2160/keyart/{id}-backdrop_wide"
+        case "title_logo":
+            return f"https://imgsrv.crunchyroll.com/cdn-cgi/image/fit=contain,format=auto,quality=85,width=800,height=310/keyart/{id}-title_logo-en-us"
+        case _:
+            return None
+
+
 def dump(data) -> None:
     xbmc.log(dumps(data, indent=4), xbmc.LOGINFO)
 

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -109,11 +109,16 @@ def add_item(
             li.addContextMenuItems(cm)
 
     # set media image
-    li.setArt({"thumb": info.get("thumb", "DefaultFolder.png"),
-               "poster": info.get("poster", info.get("thumb", "DefaultFolder.png")),
-               "banner": info.get("thumb", "DefaultFolder.png"),
-               "fanart": info.get("fanart", xbmcvfs.translatePath(G.args.addon.getAddonInfo("fanart"))),
-               "icon": info.get("thumb", "DefaultFolder.png")})
+    li.setArt({
+        "thumb": info.get("thumb", "DefaultFolder.png"),
+        "fanart": info.get("fanart", xbmcvfs.translatePath(G.args.addon.getAddonInfo("fanart"))),
+        "poster": info.get("poster", info.get("thumb", "DefaultFolder.png")),
+        "landscape": info.get("landscape", info.get("thumb", 'DefaultFolder.png')),
+        "banner": info.get("thumb", "DefaultFolder.png"),
+        "clearlogo": info.get("clearlogo"),
+        "clearart": info.get("clearart"),
+        "icon": info.get("thumb", "DefaultFolder.png")
+    })
 
     if callbacks:
         for cb in callbacks:


### PR DESCRIPTION
Implements the lastest artworks added by Crunchyroll. You can see them in most of series homepage (e.g. https://www.crunchyroll.com/series/GP5HJ84P7/gachiakuta):
* backdrop_wide (which is the page background)
* title_logo (which is the series logo)

I follow the Kodi artwork type definition from https://kodi.wiki/view/Artwork_types#fanart, which is:
* thumb: episode thumbnail
* poster: the series poster
* fanart: a screen background without logo
* landscape: same aspect ratio of fanart, but with logo, this is a poster but in landscape format (same as netflix poster)
* clearlogo: the series logo with transparent background
* clearart: the series logo with additional key artworks

Additionaly, episode thumb may be unique by episode. If we need a fancy image for episode backgrounds or wide posters, the theme should use fanart or landscape.

And as you can see in the screenshot below, it works like a charm!
<img width="1920" height="1080" alt="Screenshot_20260106_225846" src="https://github.com/user-attachments/assets/305598c3-fd45-402a-98cf-3d42fdf78033" />