### PR TITLE
Add support for ASEAN subtitle languages

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -122,6 +122,26 @@ msgctxt "#30032"
 msgid "Hindi"
 msgstr ""
 
+msgctxt "#30033"
+msgid "Indonesian"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Malay"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Chinese (Simplified)"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Chinese (Traditional)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Thai"
+msgstr ""
+
 
 msgctxt "#30038"
 msgid "Filter available dubs"
@@ -416,3 +436,7 @@ msgstr "Abbrechen"
 msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- ODER QR-CODE SCANNEN -"
+
+msgctxt "#30314"
+msgid "Vietnamese"
+msgstr ""

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -80,7 +80,9 @@ msgctxt "#30021"
 msgid "English"
 msgstr "Englisch"
 
-# 30022 free
+msgctxt "#30022"
+msgid "Vietnamese"
+msgstr ""
 
 msgctxt "#30023"
 msgid "Spanish"
@@ -437,6 +439,3 @@ msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- ODER QR-CODE SCANNEN -"
 
-msgctxt "#30314"
-msgid "Vietnamese"
-msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -428,7 +428,7 @@ msgctxt "#30312"
 msgid "Cancel"
 msgstr ""
 
-msgctxt "#30312"
+msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr ""
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -114,6 +114,26 @@ msgctxt "#30032"
 msgid "Hindi"
 msgstr ""
 
+msgctxt "#30033"
+msgid "Indonesian"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Malay"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Chinese (Simplified)"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Chinese (Traditional)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Thai"
+msgstr ""
+
 
 msgctxt "#30038"
 msgid "Filter available dubs"
@@ -410,4 +430,8 @@ msgstr ""
 
 msgctxt "#30312"
 msgid "- OR SCAN QR CODE -"
+msgstr ""
+
+msgctxt "#30314"
+msgid "Vietnamese"
 msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -72,7 +72,9 @@ msgctxt "#30021"
 msgid "English"
 msgstr ""
 
-# 30022 free
+msgctxt "#30022"
+msgid "Vietnamese"
+msgstr ""
 
 msgctxt "#30023"
 msgid "Spanish"
@@ -432,6 +434,3 @@ msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr ""
 
-msgctxt "#30314"
-msgid "Vietnamese"
-msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -79,7 +79,9 @@ msgctxt "#30021"
 msgid "English"
 msgstr "Inglés"
 
-# 30022 free
+msgctxt "#30022"
+msgid "Vietnamese"
+msgstr ""
 
 msgctxt "#30023"
 msgid "Spanish"
@@ -438,6 +440,3 @@ msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- O ESCANEAR CÓDIGO QR -"
 
-msgctxt "#30314"
-msgid "Vietnamese"
-msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -121,6 +121,26 @@ msgctxt "#30032"
 msgid "Hindi"
 msgstr ""
 
+msgctxt "#30033"
+msgid "Indonesian"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Malay"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Chinese (Simplified)"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Chinese (Traditional)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Thai"
+msgstr ""
+
 
 msgctxt "#30038"
 msgid "Filter available dubs"
@@ -417,3 +437,7 @@ msgstr "Cancelar"
 msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- O ESCANEAR CÓDIGO QR -"
+
+msgctxt "#30314"
+msgid "Vietnamese"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -79,7 +79,9 @@ msgctxt "#30021"
 msgid "English"
 msgstr "Anglais"
 
-# 30022 free
+msgctxt "#30022"
+msgid "Vietnamese"
+msgstr ""
 
 msgctxt "#30023"
 msgid "Spanish"
@@ -435,6 +437,3 @@ msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- OU SCANNER LE QR CODE -"
 
-msgctxt "#30314"
-msgid "Vietnamese"
-msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -121,6 +121,26 @@ msgctxt "#30032"
 msgid "Hindi"
 msgstr "Hindi"
 
+msgctxt "#30033"
+msgid "Indonesian"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Malay"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Chinese (Simplified)"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Chinese (Traditional)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Thai"
+msgstr ""
+
 
 msgctxt "#30038"
 msgid "Filter available dubs"
@@ -414,3 +434,7 @@ msgstr "Annuler"
 msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- OU SCANNER LE QR CODE -"
+
+msgctxt "#30314"
+msgid "Vietnamese"
+msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -79,7 +79,9 @@ msgctxt "#30021"
 msgid "English"
 msgstr "Inglês"
 
-# 30022 free
+msgctxt "#30022"
+msgid "Vietnamese"
+msgstr ""
 
 msgctxt "#30023"
 msgid "Spanish"
@@ -435,6 +437,3 @@ msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- OU DIGITALIZAR QR CODE -"
 
-msgctxt "#30314"
-msgid "Vietnamese"
-msgstr ""

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -121,6 +121,26 @@ msgctxt "#30032"
 msgid "Hindi"
 msgstr ""
 
+msgctxt "#30033"
+msgid "Indonesian"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Malay"
+msgstr ""
+
+msgctxt "#30035"
+msgid "Chinese (Simplified)"
+msgstr ""
+
+msgctxt "#30036"
+msgid "Chinese (Traditional)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "Thai"
+msgstr ""
+
 
 msgctxt "#30038"
 msgid "Filter available dubs"
@@ -414,3 +434,7 @@ msgstr "Cancelar"
 msgctxt "#30313"
 msgid "- OR SCAN QR CODE -"
 msgstr "- OU DIGITALIZAR QR CODE -"
+
+msgctxt "#30314"
+msgid "Vietnamese"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -38,7 +38,7 @@
                             <option label="30035">zh-CN</option>
                             <option label="30036">zh-TW</option>
                             <option label="30037">th-TH</option>
-                            <option label="30314">vi-VN</option>
+                            <option label="30022">vi-VN</option>
                         </options>
                     </constraints>
                     <control type="list" format="string">
@@ -66,7 +66,7 @@
                             <option label="30035">zh-CN</option>
                             <option label="30036">zh-TW</option>
                             <option label="30037">th-TH</option>
-                            <option label="30314">vi-VN</option>
+                            <option label="30022">vi-VN</option>
                         </options>
                         <allowempty>true</allowempty>
                     </constraints>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -33,6 +33,12 @@
                             <option label="30030">it-IT</option>
                             <option label="30031">ru-RU</option>
                             <option label="30032">hi-IN</option>
+                            <option label="30033">id-ID</option>
+                            <option label="30034">ms-MY</option>
+                            <option label="30035">zh-CN</option>
+                            <option label="30036">zh-TW</option>
+                            <option label="30037">th-TH</option>
+                            <option label="30314">vi-VN</option>
                         </options>
                     </constraints>
                     <control type="list" format="string">
@@ -55,6 +61,12 @@
                             <option label="30030">it-IT</option>
                             <option label="30031">ru-RU</option>
                             <option label="30032">hi-IN</option>
+                            <option label="30033">id-ID</option>
+                            <option label="30034">ms-MY</option>
+                            <option label="30035">zh-CN</option>
+                            <option label="30036">zh-TW</option>
+                            <option label="30037">th-TH</option>
+                            <option label="30314">vi-VN</option>
                         </options>
                         <allowempty>true</allowempty>
                     </constraints>


### PR DESCRIPTION
Adds support for Indonesian (id-ID), Malay (ms-MY), Chinese Simplified (zh-CN), Chinese Traditional (zh-TW), Thai (th-TH), and Vietnamese (vi-VN) subtitle languages to the plugin settings.

Softsub logic is broken however, so I didn't do any patch since my only aim is to add support to these language and don't really understand CR API, so hardsub is fine.

To test these language, user must be located in ASEAN or connected to any countries listed through VPN.