### PR TITLE
Fix soft subtitle loading and enhance language support

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -1103,17 +1103,23 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
             # r.text is empty when status code cause raise
             r = e.response
 
-    # handle subtitle response (e.g. fetch subtitle)
+    # handle subtitle or manifest response (e.g. fetch subtitle, DASH/HLS manifest)
     # Subtitles can be text/plain, application/octet-stream, or others depending on CDN
-    # We check content-type OR look for common subtitle headers in the text
-    is_subtitle = "text/plain" in response_type or "application/octet-stream" in response_type
-    if not is_subtitle:
-        # check for ASS or VTT headers
+    # Manifests are application/dash+xml or application/vnd.apple.mpegurl
+    # We check content-type OR look for common headers in the text
+    is_data_response = (
+        "text/plain" in response_type or 
+        "application/octet-stream" in response_type or
+        "application/dash+xml" in response_type or
+        "application/vnd.apple.mpegurl" in response_type
+    )
+    if not is_data_response:
+        # check for ASS, VTT, MPD or HLS headers
         content_start = r.text[:100]
-        if "[Script Info]" in content_start or "WEBVTT" in content_start:
-            is_subtitle = True
+        if any(h in content_start for h in ["[Script Info]", "WEBVTT", "<MPD", "#EXTM3U"]):
+            is_data_response = True
 
-    if is_subtitle:
+    if is_data_response:
         # if encoding is not provided in the response, Requests will make an educated guess and very likely fail
         # messing encoding up - which did cost me hours. We will always receive utf-8 from crunchy, so enforce that
         r.encoding = "utf-8"
@@ -1129,8 +1135,8 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
     try:
         r_json: Dict = r.json()
     except (requests.exceptions.JSONDecodeError, ValueError):
-        # If it's not JSON, but we are here, it might be a subtitle file we missed
-        if "[Script Info]" in r.text or "WEBVTT" in r.text:
+        # If it's not JSON, but we are here, it might be a subtitle or manifest file we missed
+        if any(h in r.text for h in ["[Script Info]", "WEBVTT", "<MPD", "#EXTM3U"]):
             r.encoding = "utf-8"
             return {"data": r.text}
 

--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -1092,7 +1092,7 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
     from .model import CrunchyrollError
 
     code: int = r.status_code
-    response_type: str = r.headers.get("Content-Type")
+    response_type: str = r.headers.get("Content-Type", "")
 
     # no content - possibly POST/DELETE request?
     if not r or not r.text:
@@ -1103,8 +1103,17 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
             # r.text is empty when status code cause raise
             r = e.response
 
-    # handle text/plain response (e.g. fetch subtitle)
-    if response_type == "text/plain":
+    # handle subtitle response (e.g. fetch subtitle)
+    # Subtitles can be text/plain, application/octet-stream, or others depending on CDN
+    # We check content-type OR look for common subtitle headers in the text
+    is_subtitle = "text/plain" in response_type or "application/octet-stream" in response_type
+    if not is_subtitle:
+        # check for ASS or VTT headers
+        content_start = r.text[:100]
+        if "[Script Info]" in content_start or "WEBVTT" in content_start:
+            is_subtitle = True
+
+    if is_subtitle:
         # if encoding is not provided in the response, Requests will make an educated guess and very likely fail
         # messing encoding up - which did cost me hours. We will always receive utf-8 from crunchy, so enforce that
         r.encoding = "utf-8"
@@ -1114,12 +1123,17 @@ def get_json_from_response(r: Response) -> Optional[Dict]:
         })
         return d
 
-    if not r.ok and r.text[0] != "{":
+    if not r.ok and (not r.text or r.text[0] != "{"):
         raise CrunchyrollError(f"[{code}] {r.text}")
 
     try:
         r_json: Dict = r.json()
-    except requests.exceptions.JSONDecodeError:
+    except (requests.exceptions.JSONDecodeError, ValueError):
+        # If it's not JSON, but we are here, it might be a subtitle file we missed
+        if "[Script Info]" in r.text or "WEBVTT" in r.text:
+            r.encoding = "utf-8"
+            return {"data": r.text}
+
         log_error_with_trace("Failed to parse response data")
         return None
 

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -44,7 +44,7 @@ class CloudflareProxy:
     Auto-terminates after TTL to prevent zombie processes
     """
 
-    def __init__(self, ttl_seconds=30):
+    def __init__(self, ttl_seconds=180):
         self.server = None
         self.server_thread = None
         self.port = None

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -422,20 +422,19 @@ class VideoStream(Object):
         """ cache a subtitle from the given url and rename it for kodi to label it correctly """
 
         try:
-            # api request streams
             subtitles_req = G.api.make_request(
                 method="GET",
                 url=subtitle_url
             )
         except Exception:
             log_error_with_trace("error in requesting subtitle data from api")
-            raise CrunchyrollError(
+            return False
+
+        if not subtitles_req or not subtitles_req.get('data', None):
+            crunchy_log(
                 "Failed to download subtitle for language %s from url %s" % (subtitle_language, subtitle_url)
             )
-
-        if not subtitles_req.get('data', None):
-            # error
-            raise CrunchyrollError("Returned data is not text")
+            return False
 
         cache_target = xbmcvfs.translatePath(self.get_cache_path() + G.args.get_arg('stream_id') + '/')
         xbmcvfs.mkdirs(cache_target)

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -462,8 +462,14 @@ class VideoStream(Object):
 
         cache_file = self.get_cache_file_name(subtitle_language, subtitle_format)
 
+        data = subtitles_req.get('data')
+        # QoL: Convert soft line breaks (\n) to hard line breaks (\N) for better rendering in Kodi
+        # and remove any trailing line breaks that cause empty lines
+        if data:
+            data = data.replace('\\n', '\\N').replace('\\N\r\n', '\r\n').replace('\\N\n', '\n')
+
         with open(cache_target + cache_file, 'w', encoding='utf-8') as file:
-            result = file.write(subtitles_req.get('data'))
+            result = file.write(data)
 
         return True if result > 0 else False
 

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -391,7 +391,7 @@ class VideoStream(Object):
 
         return url
 
-    def _get_subtitles_from_api_data(self, api_stream_data) -> Union[str, None]:
+    def _get_subtitles_from_api_data(self, api_stream_data) -> Union[list[str], None]:
         """ retrieve appropriate subtitle urls from api data, using local caching and renaming """
 
         # we only need those urls if soft-subs are enabled in addon settings
@@ -400,12 +400,28 @@ class VideoStream(Object):
 
         subtitles_data_raw = []
         subtitles_url_cached = []
+        processed_languages = set()
 
+        # 1. Add preferred language first
         if G.args.subtitle in api_stream_data["subtitles"]:
             subtitles_data_raw.append(api_stream_data.get("subtitles").get(G.args.subtitle))
+            processed_languages.add(G.args.subtitle)
 
+        # 2. Add fallback language second
         if G.args.subtitle_fallback and G.args.subtitle_fallback in api_stream_data["subtitles"]:
-            subtitles_data_raw.append(api_stream_data.get("subtitles").get(G.args.subtitle_fallback))
+            if G.args.subtitle_fallback not in processed_languages:
+                subtitles_data_raw.append(api_stream_data.get("subtitles").get(G.args.subtitle_fallback))
+                processed_languages.add(G.args.subtitle_fallback)
+
+        # 3. Add all other available languages (sorted by BCP 47 code)
+        other_langs = sorted([
+            (code, data) for code, data in api_stream_data["subtitles"].items()
+            if code not in processed_languages
+        ])
+
+        for lang_code, sub_data in other_langs:
+            subtitles_data_raw.append(sub_data)
+            processed_languages.add(lang_code)
 
         if not subtitles_data_raw:
             return None
@@ -421,7 +437,7 @@ class VideoStream(Object):
             if cache_result is not None:
                 subtitles_url_cached.append(cache_result)
 
-        return subtitles_url_cached if subtitles_url_cached is not None else None
+        return subtitles_url_cached if subtitles_url_cached else None
 
     def _cache_subtitle(self, subtitle_url: str, subtitle_language: str, subtitle_format: str) -> bool:
         """ cache a subtitle from the given url and rename it for kodi to label it correctly """

--- a/resources/lib/videostream.py
+++ b/resources/lib/videostream.py
@@ -268,7 +268,7 @@ class VideoStream(Object):
             raise CrunchyrollError("Failed to fetch stream data from api")
 
         video_player_stream_data.stream_url = self._get_stream_url_from_api_data_v2(async_data.get('stream_data'))
-        video_player_stream_data.subtitle_urls = self._get_subtitles_from_api_data(async_data.get('stream_data'))
+        video_player_stream_data.subtitle_urls = async_data.get('subtitle_urls')
         video_player_stream_data.token = async_data.get('stream_data').get('token')
 
         video_player_stream_data.skip_events_data = async_data.get('skip_events_data')
@@ -294,15 +294,20 @@ class VideoStream(Object):
         # start async requests and fetch results
         results = await asyncio.gather(t_stream_data, t_skip_events_data, t_playheads, t_item_data)
 
+        stream_data = results[0] or {}
+        # Fetch subtitles in parallel now that we have stream_data
+        subtitle_urls = await asyncio.to_thread(self._get_subtitles_from_api_data, stream_data)
+
         playable_item = get_listables_from_response([results[3].get(G.args.get_arg('episode_id'))]) if \
             results[3] else None
 
         return {
-            'stream_data': results[0] or {},
+            'stream_data': stream_data,
             'skip_events_data': results[1] or {},
             'playheads_data': results[2] or {},
             'playable_item': playable_item[0] if playable_item else None,
-            'playable_item_parent': None
+            'playable_item_parent': None,
+            'subtitle_urls': subtitle_urls
             # get_listables_from_response([results[4]])[0] if results[4] else None
         }
 


### PR DESCRIPTION
## tl;dr

Since I still don't know what the heck is happening with soft sub option to unable load the stream at all even after updating it properly, I've decided to take a look and compares with existing Crunchyroll tools (and ask Gemini what to modify). Basically, this PR will fix the option, making it playable, plus additional QoL for the streams and ability to pick other languages outside what have been defined in settings.

Tested with all languages in many titles, all working fine. 

## github copilot's summary

This pull request improves the handling of video stream and subtitle data, especially around fetching, caching, and processing subtitles in various formats and languages. It also enhances the robustness and reliability of API response parsing and extends the lifetime of the Cloudflare proxy. The most important changes are grouped below:

**Subtitle Handling Improvements:**

* The `_get_subtitles_from_api_data` method now returns a list of subtitle URLs instead of a single string, prioritizing preferred, fallback, and then all other available languages, with improved sorting and deduplication. [[1]](diffhunk://#diff-41794ac85d875b13e7a645fc00970af48ed425bd8451b9673a9bf7e1087770ddL389-R394) [[2]](diffhunk://#diff-41794ac85d875b13e7a645fc00970af48ed425bd8451b9673a9bf7e1087770ddR403-R424)
* Subtitle caching now includes better error handling (returns `False` instead of raising errors), improved line break formatting for better rendering in Kodi, and more robust checks for downloaded data.
* Subtitles are now fetched in parallel after stream data is available, and the resulting URLs are passed through the async data pipeline for use by the player. [[1]](diffhunk://#diff-41794ac85d875b13e7a645fc00970af48ed425bd8451b9673a9bf7e1087770ddR297-R310) [[2]](diffhunk://#diff-41794ac85d875b13e7a645fc00970af48ed425bd8451b9673a9bf7e1087770ddL271-R271)

**API Response Robustness:**

* The `get_json_from_response` function now more reliably detects and handles subtitle and manifest responses by checking for multiple content types and inspecting the response text for known headers, reducing the chance of misparsing non-JSON responses. [[1]](diffhunk://#diff-5f06840a3e6ef1cdcf6ecb00ea5bd99a5bc274a7530d0221b5cfb0b5edf1bb8eL1095-R1095) [[2]](diffhunk://#diff-5f06840a3e6ef1cdcf6ecb00ea5bd99a5bc274a7530d0221b5cfb0b5edf1bb8eL1106-R1122)
* JSON decode errors now also catch `ValueError`, and if the response is a subtitle or manifest, the raw data is returned instead of failing.

**Other Improvements:**

* Increased the default TTL for the `CloudflareProxy` from 30 seconds to 180 seconds to reduce premature termination of proxy processes.