### PR TITLE
Add "Queue (Unplayed)" menu entry to filter out watched episodes in the queue

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -212,6 +212,10 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Fortsetzen"
 
+msgctxt "#30048"
+msgid "Queue (Unplayed)"
+msgstr "Playlist (Ungesehen)"
+
 msgctxt "#30049"
 msgid "Crunchylists"
 msgstr "Crunchylists"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -205,7 +205,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr ""
 
-# 30048 free
+msgctxt "#30048"
+msgid "Queue (Unplayed)"
+msgstr ""
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -211,7 +211,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Reanudar"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Queue (Unplayed)"
+msgstr "Cola (No vistos)"
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -210,7 +210,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Reprendre"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Queue (Unplayed)"
+msgstr "File d'attente (Non vus)"
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -210,7 +210,9 @@ msgctxt "#30047"
 msgid "Resume"
 msgstr "Retomar"
 
-# 30048 free
+msgctxt "#30048"
+msgid "Queue (Unplayed)"
+msgstr "Fila (Nao assistidos)"
 
 msgctxt "#30049"
 msgid "Crunchylists"

--- a/resources/lib/controller.py
+++ b/resources/lib/controller.py
@@ -66,7 +66,7 @@ def show_profiles():
         return True
 
 
-def show_queue():
+def show_queue(hide_played=False):
     """ shows anime queue/playlist
     """
     # api request
@@ -85,10 +85,14 @@ def show_queue():
         view.end_of_directory()
         return False
 
+    options = view.OPT_CTX_SEASONS | view.OPT_CTX_EPISODES  # | view.OPT_SORT_EPISODES_EXPERIMENTAL
+    if hide_played:
+        options = options | view.OPT_HIDE_WATCHED
+
     view.add_listables(
         listables=get_listables_from_response(req.get('items')),
         is_folder=False,
-        options=view.OPT_CTX_SEASONS | view.OPT_CTX_EPISODES  # | view.OPT_SORT_EPISODES_EXPERIMENTAL
+        options=options
     )
 
     view.end_of_directory("episodes", cache_to_disc=False)

--- a/resources/lib/crunchyroll.py
+++ b/resources/lib/crunchyroll.py
@@ -138,7 +138,9 @@ def check_mode():
         show_main_menu()
 
     elif mode == "queue":
-        controller.show_queue()
+        controller.show_queue(hide_played = False)
+    elif mode == "queue_unplayed":
+        controller.show_queue(hide_played = True)
     elif mode == "search":
         controller.search_anime()
     elif mode == "history":
@@ -202,6 +204,8 @@ def show_main_menu():
     """
     view.add_item({"title": G.args.addon.getLocalizedString(30040),
                    "mode": "queue"})
+    view.add_item({"title": G.args.addon.getLocalizedString(30048),
+                   "mode": "queue_unplayed"})
     view.add_item({"title": G.args.addon.getLocalizedString(30047),
                    "mode": "resume"})
     view.add_item({"title": G.args.addon.getLocalizedString(30041),

--- a/resources/lib/view.py
+++ b/resources/lib/view.py
@@ -143,6 +143,7 @@ OPT_CTX_SEASONS = 4  # add context menu to jump to series
 OPT_CTX_EPISODES = 8  # add context menu to jump to episodes
 OPT_NO_SEASON_TITLE = 16  # only show title of episode (with numbering)
 OPT_SORT_EPISODES_EXPERIMENTAL = 32  # sort un-viewed queue items to top
+OPT_HIDE_WATCHED = 64  # filter out fully watched items
 
 
 # actually not sure if this works, as the requests lib is not async
@@ -291,6 +292,10 @@ def add_listables(
     if options and options & OPT_SORT_EPISODES_EXPERIMENTAL:  # needs check for episodes
         from .utils import sort_episodes
         listables = sort_episodes(listables)
+
+    # filter out watched episodes if option is enabled
+    if options and options & OPT_HIDE_WATCHED:
+        listables = [listable for listable in listables if not hasattr(listable, 'playcount') or listable.playcount != 1]
 
     # add listable items to kodi
     for listable in listables:


### PR DESCRIPTION
I have manually modifying the plugin to add an unplayed queue for years. I have found it to be way more usable to find the next/newest episode to watch. So I thought it was time to create a PR. I have also tried the OPT_SORT_EPISODES_EXPERIMENTAL, but found it not as usable because it is based on the released date so old series wouldn't show near the top of the queue. 